### PR TITLE
Feat(#4): 공통응답 예외 핸들러 구현

### DIFF
--- a/src/main/java/org/nexters/jaknaeso/common/controller/ApiControllerAdvice.java
+++ b/src/main/java/org/nexters/jaknaeso/common/controller/ApiControllerAdvice.java
@@ -1,0 +1,67 @@
+package org.nexters.jaknaeso.common.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.nexters.jaknaeso.common.support.error.CustomException;
+import org.nexters.jaknaeso.common.support.error.ErrorType;
+import org.nexters.jaknaeso.common.support.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+        switch (e.getErrorType().getLogLevel()) {
+            case ERROR -> log.error("CustomException : {}", e.getMessage(), e);
+            case WARN -> log.warn("CustomException : {}", e.getMessage(), e);
+            default -> log.info("CustomException : {}", e.getMessage(), e);
+        }
+        return new ResponseEntity<>(ApiResponse.error(e.getErrorType(), e.getData()), e.getErrorType().getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        log.debug("Validation error occurred: {}", e.getMessage(), e);
+
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        List<Map<String, String>> validationErrors = fieldErrors.stream()
+            .map(error -> Map.of(
+                "field", error.getField(),
+                "message", error.getDefaultMessage()
+            ))
+            .toList();
+
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.METHOD_ARGUMENT_NOT_VALID, validationErrors), ErrorType.METHOD_ARGUMENT_NOT_VALID.getStatus());
+    }
+
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<?>> handleBindException(BindException e) {
+        log.warn("Binding error occurred: {}", e.getMessage(), e);
+
+        List<FieldError> fieldErrors = e.getBindingResult().getFieldErrors();
+        List<Map<String, String>> validationErrors = fieldErrors.stream()
+            .map(error -> Map.of(
+                "field", error.getField(),
+                "message", error.getDefaultMessage()
+            ))
+            .toList();
+
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.BINDING_ERROR, validationErrors), ErrorType.BINDING_ERROR.getStatus());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+        log.error("Exception : {}", e.getMessage(), e);
+        return new ResponseEntity<>(ApiResponse.error(ErrorType.DEFAULT_ERROR), ErrorType.DEFAULT_ERROR.getStatus());
+    }
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/CustomException.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/CustomException.java
@@ -1,0 +1,24 @@
+package org.nexters.jaknaeso.common.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorType errorType;
+
+    private final Object data;
+
+    public CustomException(ErrorType errorType) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = null;
+    }
+
+    public CustomException(ErrorType errorType, Object data) {
+        super(errorType.getMessage());
+        this.errorType = errorType;
+        this.data = data;
+    }
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorCode.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorCode.java
@@ -2,6 +2,7 @@ package org.nexters.jaknaeso.common.support.error;
 
 public enum ErrorCode {
 
-    E500
+    E500,
+    E400
 
 }

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorCode.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorCode.java
@@ -1,0 +1,7 @@
+package org.nexters.jaknaeso.common.support.error;
+
+public enum ErrorCode {
+
+    E500
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorMessage.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorMessage.java
@@ -1,0 +1,26 @@
+package org.nexters.jaknaeso.common.support.error;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorMessage {
+
+    private final String code;
+
+    private final String message;
+
+    private final Object data;
+
+    public ErrorMessage(ErrorType errorType) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = null;
+    }
+
+    public ErrorMessage(ErrorType errorType, Object data) {
+        this.code = errorType.getCode().name();
+        this.message = errorType.getMessage();
+        this.data = data;
+    }
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorType.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorType.java
@@ -1,0 +1,28 @@
+package org.nexters.jaknaeso.common.support.error;
+
+import lombok.Getter;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorType {
+
+    DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
+            LogLevel.ERROR);
+
+    private final HttpStatus status;
+
+    private final ErrorCode code;
+
+    private final String message;
+
+    private final LogLevel logLevel;
+
+    ErrorType(HttpStatus status, ErrorCode code, String message, LogLevel logLevel) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+        this.logLevel = logLevel;
+    }
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorType.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/error/ErrorType.java
@@ -8,7 +8,10 @@ import org.springframework.http.HttpStatus;
 public enum ErrorType {
 
     DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "An unexpected error has occurred.",
-            LogLevel.ERROR);
+            LogLevel.ERROR),
+    METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST,ErrorCode.E400,"Method argument validation failed.", LogLevel.DEBUG),
+    BINDING_ERROR(HttpStatus.BAD_REQUEST,ErrorCode.E400,"Data binding failed.", LogLevel.WARN),
+    ;
 
     private final HttpStatus status;
 

--- a/src/main/java/org/nexters/jaknaeso/common/support/response/ApiResponse.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/response/ApiResponse.java
@@ -1,0 +1,37 @@
+package org.nexters.jaknaeso.common.support.response;
+
+import lombok.Getter;
+import org.nexters.jaknaeso.common.support.error.ErrorMessage;
+import org.nexters.jaknaeso.common.support.error.ErrorType;
+
+@Getter
+public class ApiResponse<S> {
+    private final ResultType result;
+
+    private final S data;
+
+    private final ErrorMessage error;
+
+    private ApiResponse(ResultType result, S data, ErrorMessage error) {
+        this.result = result;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static ApiResponse<?> success() {
+        return new ApiResponse<>(ResultType.SUCCESS, null, null);
+    }
+
+    public static <S> ApiResponse<S> success(S data) {
+        return new ApiResponse<>(ResultType.SUCCESS, data, null);
+    }
+
+    public static ApiResponse<?> error(ErrorType error) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error));
+    }
+
+    public static ApiResponse<?> error(ErrorType error, Object errorData) {
+        return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error, errorData));
+    }
+
+}

--- a/src/main/java/org/nexters/jaknaeso/common/support/response/ResultType.java
+++ b/src/main/java/org/nexters/jaknaeso/common/support/response/ResultType.java
@@ -1,0 +1,7 @@
+package org.nexters.jaknaeso.common.support.response;
+
+public enum ResultType {
+
+    SUCCESS, ERROR
+
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
공통 응답과 예외 핸들러 정의하였습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 공통응답 구현
- 예외 핸들러 구현

## 고민한 점
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
지금 형태로 가게 되면 에러를 모두 Common 패키지에 존재하는 ErrorCode와 ErrorType에 의해 관리 되어야 하는데 확장성이나 각 도메인에서 발생하는 에러를 따로 정의하려고 한다면 인터페이스로 추상화하도록 하겠습니다.

성공응답 보낼 때는 ResponseEntity로 감싸지 않고 ApiResponse로 바로 보낼 생각으로 만들었습니다. 예외 핸들링 시에는 httpstatus를 내려주기 위해서 ResponseEntity로 감쌌습니다.

아래의 응답 예시를 보시고 `@JsonInclude(JsonInclude.Include.NON_NULL)` 을 통해서 null 응답에 대해서는 보내지 않는 편이 좋을지도 고려해주시면 감사하겠습니다.

### 현재 응답 예시 

성공 응답
```json
{
    "result": "SUCCESS",
    "data": [
        {
            "id": 1,
            "name": "나민혁",
            "age": "26"
        },
        {
            "id": 2,
            "name": "김이박",
            "age": "10"
        }
    ],
    "error": null
}
```

예외 발생 응답
```json
{
    "result": "ERROR",
    "data": null,
    "error": {
        "code": "E500",
        "message": "An unexpected error has occurred",
        "data": null
    }
}
```

```json
{
    "result": "ERROR",
    "data": null,
    "error": {
        "code": "E400",
        "message": "Method argument validation failed",
        "data": [
            {
                "field": "email",
                "message": "이메일 형식이 올바르지 않습니다"
            },
            {
                "field": "age",
                "message": "나이는 0보다 커야 합니다"
            }
        ]
    }
}
```