### PR TITLE
Fix(#46): 카카오 API 호출 오류

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoAuthClient.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoAuthClient.java
@@ -1,11 +1,8 @@
 package org.nexters.jaknaesocore.domain.auth.restclient;
 
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
-
 import org.nexters.jaknaesocore.domain.auth.restclient.dto.KakaoTokenCommand;
 import org.nexters.jaknaesocore.domain.auth.restclient.dto.KakaoTokenResponse;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
 
@@ -13,6 +10,5 @@ import org.springframework.web.service.annotation.PostExchange;
 public interface KakaoAuthClient {
 
   @PostExchange("/oauth/token")
-  KakaoTokenResponse requestToken(
-      @RequestHeader(CONTENT_TYPE) String contentType, @RequestBody KakaoTokenCommand command);
+  KakaoTokenResponse requestToken(@RequestBody KakaoTokenCommand command);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoClient.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoClient.java
@@ -1,7 +1,6 @@
 package org.nexters.jaknaesocore.domain.auth.restclient;
 
 import static org.springframework.http.HttpHeaders.AUTHORIZATION;
-import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
 import org.nexters.jaknaesocore.domain.auth.restclient.dto.KakaoUserInfoResponse;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -12,7 +11,5 @@ import org.springframework.web.service.annotation.HttpExchange;
 public interface KakaoClient {
 
   @GetExchange("/v2/user/me")
-  KakaoUserInfoResponse requestUserInfo(
-      @RequestHeader(AUTHORIZATION) String authorization,
-      @RequestHeader(CONTENT_TYPE) String contentType);
+  KakaoUserInfoResponse requestUserInfo(@RequestHeader(AUTHORIZATION) String authorization);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/service/OauthService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/auth/service/OauthService.java
@@ -53,7 +53,9 @@ public class OauthService {
   @Transactional
   public Long kakaoLogin(final KakaoLoginCommand command) {
     KakaoTokenResponse token = getKakaoToken(command.authorizationCode());
+    log.info("kakao 토큰 받아오기 성공");
     KakaoUserInfoResponse userInfo = getKakaoUserInfo(token.accessToken());
+    log.info("kakao 사용자 정보 받아오기 성공");
 
     String oauthId = userInfo.id().toString();
     SocialAccount socialAccount = socialAccountRepository.saveKakaoAccount(oauthId);
@@ -67,13 +69,13 @@ public class OauthService {
   }
 
   private KakaoUserInfoResponse getKakaoUserInfo(final String accessToken) {
-    return kakaoClient.requestUserInfo(BEARER_PREFIX + accessToken, FORM_URLENCODED_MEDIA_TYPE);
+    return kakaoClient.requestUserInfo(BEARER_PREFIX + accessToken);
   }
 
   private KakaoTokenResponse getKakaoToken(final String authorizationCode) {
     KakaoTokenCommand command =
         KakaoTokenCommand.of(clientId, clientSecret, redirectUri, authorizationCode);
-    return kakaoAuthClient.requestToken(FORM_URLENCODED_MEDIA_TYPE, command);
+    return kakaoAuthClient.requestToken(command);
   }
 
   @Transactional

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoClientTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/auth/restclient/KakaoClientTest.java
@@ -20,7 +20,6 @@ class KakaoClientTest extends IntegrationTest {
     String mediaType =
         MediaTypeValueBuilder.builder(APPLICATION_FORM_URLENCODED_VALUE).charset("utf-8").build();
 
-    thenThrownBy(() -> kakaoClient.requestUserInfo("", mediaType))
-        .isInstanceOf(RestClientException.class);
+    thenThrownBy(() -> kakaoClient.requestUserInfo("")).isInstanceOf(RestClientException.class);
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/auth/service/OauthServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/auth/service/OauthServiceTest.java
@@ -41,9 +41,9 @@ class OauthServiceTest extends ServiceTest {
         KakaoTokenCommand.of(
             "client-id", "client-secret", "redirect-uri", command.authorizationCode());
 
-    given(kakaoAuthClient.requestToken(MEDIA_TYPE, tokenCommand))
+    given(kakaoAuthClient.requestToken(tokenCommand))
         .willReturn(new KakaoTokenResponse("bearer", "access token", 1, "refresh token", 1));
-    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token", MEDIA_TYPE))
+    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token"))
         .willReturn(new KakaoUserInfoResponse(oauthId));
     given(socialAccountRepository.saveKakaoAccount(oauthId.toString())).willReturn(newAccount);
     given(memberRepository.save(any(Member.class))).willReturn(newMember);
@@ -65,9 +65,9 @@ class OauthServiceTest extends ServiceTest {
         KakaoTokenCommand.of(
             "client-id", "client-secret", "redirect-uri", command.authorizationCode());
 
-    given(kakaoAuthClient.requestToken(MEDIA_TYPE, tokenCommand))
+    given(kakaoAuthClient.requestToken(tokenCommand))
         .willReturn(new KakaoTokenResponse("bearer", "access token", 1, "refresh token", 1));
-    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token", MEDIA_TYPE))
+    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token"))
         .willReturn(new KakaoUserInfoResponse(oauthId));
     given(socialAccountRepository.saveKakaoAccount(oauthId.toString())).willReturn(account);
 
@@ -82,8 +82,7 @@ class OauthServiceTest extends ServiceTest {
         KakaoTokenCommand.of(
             "client-id", "client-secret", "redirect-uri", command.authorizationCode());
 
-    given(kakaoAuthClient.requestToken(MEDIA_TYPE, tokenCommand))
-        .willThrow(RestClientException.class);
+    given(kakaoAuthClient.requestToken(tokenCommand)).willThrow(RestClientException.class);
 
     thenThrownBy(() -> oauthService.kakaoLogin(command)).isInstanceOf(RestClientException.class);
   }
@@ -96,9 +95,9 @@ class OauthServiceTest extends ServiceTest {
         KakaoTokenCommand.of(
             "client-id", "client-secret", "redirect-uri", command.authorizationCode());
 
-    given(kakaoAuthClient.requestToken(MEDIA_TYPE, tokenCommand))
+    given(kakaoAuthClient.requestToken(tokenCommand))
         .willReturn(new KakaoTokenResponse("bearer", "access token", 1, "refresh token", 1));
-    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token", MEDIA_TYPE))
+    given(kakaoClient.requestUserInfo(BEARER_PREFIX + "access token"))
         .willThrow(RestClientException.class);
 
     thenThrownBy(() -> oauthService.kakaoLogin(command)).isInstanceOf(RestClientException.class);


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
카카오 API 호출에서 http message converter 관련 에러가 발생하여 content-type 헤더를 넣지 않도록 수정

- api 호출 및 응답
```
curl -v -X POST "http://localhost:8080/api/v1/auth/kakao-login" -H "Content-Type: application/json" -d '{"code": "code"}'
...

< HTTP/1.1 500 
< Vary: Origin
< Vary: Access-Control-Request-Method
< Vary: Access-Control-Request-Headers
< X-Content-Type-Options: nosniff
< X-XSS-Protection: 0
< Cache-Control: no-cache, no-store, max-age=0, must-revalidate
< Pragma: no-cache
< Expires: 0
< X-Frame-Options: DENY
< Content-Type: application/json
< Transfer-Encoding: chunked
< Date: Sun, 02 Feb 2025 06:19:25 GMT
< Connection: close
< 
* Closing connection
{"result":"ERROR","data":null,"error":{"code":"E500","message":"예기치 않은 오류가 발생했습니다.","data":null}}%
```

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
`application/x-www-form-urlencoded;charset=utf-8` content-type 삭제
