### PR TITLE
Feat(#31) 현재 진행 중인 질문 목록 조회

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/model/BaseTimeEntity.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/model/BaseTimeEntity.java
@@ -1,12 +1,15 @@
 package org.nexters.jaknaesocore.common.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @MappedSuperclass
 public class BaseTimeEntity extends BaseEntity {

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -15,6 +15,8 @@ public class CustomException extends RuntimeException {
       new CustomException(ErrorType.INCORRECT_TOKEN_FORMAT);
   public static final CustomException INVALID_APPLE_ID_TOKEN =
       new CustomException(ErrorType.INVALID_APPLE_ID_TOKEN);
+  public static final CustomException NOT_READY_FOR_NEXT_BUNDLE =
+      new CustomException(ErrorType.NOT_READY_FOR_NEXT_BUNDLE);
 
   private final ErrorType errorType;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
@@ -27,6 +27,10 @@ public enum ErrorType {
   // business
   INVALID_APPLE_ID_TOKEN(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "유효하지 않은 애플로그인입니다.", LogLevel.WARN),
+
+  // survey
+  NOT_READY_FOR_NEXT_BUNDLE(
+      HttpStatus.BAD_REQUEST, ErrorCode.E400, "다음 번들을 진행할 준비가 되지 않았습니다.", LogLevel.WARN),
   ;
 
   private final HttpStatus status;

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryDetailResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryDetailResponse.java
@@ -1,0 +1,3 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+public record SurveyHistoryDetailResponse(Long submissionId) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryResponse.java
@@ -1,0 +1,8 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+import java.util.List;
+
+public record SurveyHistoryResponse(
+    Long bundleId,
+    List<SurveyHistoryDetailResponse> surveyHistoryDetails,
+    Integer nextSurveyIndex) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundle.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundle.java
@@ -32,4 +32,13 @@ public class SurveyBundle extends BaseTimeEntity {
     int randomNum = ThreadLocalRandom.current().nextInt(list.size());
     return list.get(randomNum);
   }
+
+  public boolean isAllSubmitted(final List<SurveySubmission> submissions) {
+    return surveys.stream()
+        .allMatch(
+            survey ->
+                submissions.stream()
+                    .map(SurveySubmission::getSurvey)
+                    .anyMatch(submittedSurvey -> submittedSurvey.equals(survey)));
+  }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepository.java
@@ -1,6 +1,10 @@
 package org.nexters.jaknaesocore.domain.survey.repository;
 
+import java.util.Optional;
 import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface SurveyBundleRepository extends JpaRepository<SurveyBundle, Long> {}
+public interface SurveyBundleRepository extends JpaRepository<SurveyBundle, Long> {
+
+  Optional<SurveyBundle> findFirstByIdGreaterThanOrderByIdAsc(final Long id);
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
@@ -1,6 +1,7 @@
 package org.nexters.jaknaesocore.domain.survey.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.nexters.jaknaesocore.domain.survey.model.SurveySubmission;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,9 @@ public interface SurveySubmissionRepository extends JpaRepository<SurveySubmissi
 
   @EntityGraph(attributePaths = {"survey"})
   List<SurveySubmission> findByMember_IdAndDeletedAtIsNull(Long memberId);
+
+  Optional<SurveySubmission> findTopByMember_IdAndDeletedAtIsNullOrderByCreatedAtDesc(
+      Long memberId);
+
+  List<SurveySubmission> findByMember_IdAndSurvey_SurveyBundle_Id(Long memberId, Long bundleId);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
@@ -9,10 +9,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface SurveySubmissionRepository extends JpaRepository<SurveySubmission, Long> {
 
   @EntityGraph(attributePaths = {"survey"})
-  List<SurveySubmission> findByMember_IdAndDeletedAtIsNull(Long memberId);
+  List<SurveySubmission> findByMember_IdAndDeletedAtIsNull(final Long memberId);
 
   Optional<SurveySubmission> findTopByMember_IdAndDeletedAtIsNullOrderByCreatedAtDesc(
-      Long memberId);
+      final Long memberId);
 
-  List<SurveySubmission> findByMember_IdAndSurvey_SurveyBundle_Id(Long memberId, Long bundleId);
+  List<SurveySubmission> findByMember_IdAndSurvey_SurveyBundle_Id(
+      final Long memberId, final Long bundleId);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -55,13 +55,14 @@ public class SurveyService {
     return createCurrentBundleSurveyHistory(currentBundleId, submissions);
   }
 
-  private SurveySubmission findLatestSubmission(Long memberId) {
+  private SurveySubmission findLatestSubmission(final Long memberId) {
     return surveySubmissionRepository
         .findTopByMember_IdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId)
         .orElse(null);
   }
 
-  private List<SurveySubmission> findSubmissionsForBundle(Long memberId, Long bundleId) {
+  private List<SurveySubmission> findSubmissionsForBundle(
+      final Long memberId, final Long bundleId) {
     return surveySubmissionRepository.findByMember_IdAndSurvey_SurveyBundle_Id(memberId, bundleId);
   }
 
@@ -69,7 +70,7 @@ public class SurveyService {
     return new SurveyHistoryResponse(1L, List.of(), 1);
   }
 
-  private SurveyHistoryResponse createNextBundleSurveyHistory(Long currentBundleId) {
+  private SurveyHistoryResponse createNextBundleSurveyHistory(final Long currentBundleId) {
     return new SurveyHistoryResponse(currentBundleId + 1, List.of(), 1);
   }
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SurveyService {
 
-  private static final int DEFAULT_SIZE_OF_BUNDLE = 15;
   private final SurveyBundleRepository surveyBundleRepository;
   private final SurveySubmissionRepository surveySubmissionRepository;
 
@@ -46,10 +45,11 @@ public class SurveyService {
     if (latestSubmission == null) {
       return createInitialSurveyHistory();
     }
-    Long currentBundleId = latestSubmission.getSurvey().getSurveyBundle().getId();
+    SurveyBundle bundle = latestSubmission.getSurvey().getSurveyBundle();
+    Long currentBundleId = bundle.getId();
     List<SurveySubmission> submissions = findSubmissionsForBundle(memberId, currentBundleId);
 
-    if (hasReachedSubmissionLimit(submissions)) {
+    if (bundle.isAllSubmitted(submissions)) {
       return createNextBundleSurveyHistory(currentBundleId);
     }
     return createCurrentBundleSurveyHistory(currentBundleId, submissions);
@@ -63,10 +63,6 @@ public class SurveyService {
 
   private List<SurveySubmission> findSubmissionsForBundle(Long memberId, Long bundleId) {
     return surveySubmissionRepository.findByMember_IdAndSurvey_SurveyBundle_Id(memberId, bundleId);
-  }
-
-  private boolean hasReachedSubmissionLimit(List<SurveySubmission> submissions) {
-    return submissions.size() >= DEFAULT_SIZE_OF_BUNDLE;
   }
 
   private SurveyHistoryResponse createInitialSurveyHistory() {

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -2,6 +2,8 @@ package org.nexters.jaknaesocore.domain.survey.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryDetailResponse;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
 import org.nexters.jaknaesocore.domain.survey.model.Survey;
 import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class SurveyService {
 
+  private static final int DEFAULT_SIZE_OF_BUNDLE = 15;
   private final SurveyBundleRepository surveyBundleRepository;
   private final SurveySubmissionRepository surveySubmissionRepository;
 
@@ -35,5 +38,52 @@ public class SurveyService {
     List<SurveySubmission> surveySubmissionsByMember =
         surveySubmissionRepository.findByMember_IdAndDeletedAtIsNull(memberId);
     return new SurveySubscriptions(surveySubmissionsByMember).getSubmittedSurvey(memberId);
+  }
+
+  @Transactional(readOnly = true)
+  public SurveyHistoryResponse getSurveyHistory(final Long memberId) {
+    SurveySubmission latestSubmission = findLatestSubmission(memberId);
+    if (latestSubmission == null) {
+      return createInitialSurveyHistory();
+    }
+    Long currentBundleId = latestSubmission.getSurvey().getSurveyBundle().getId();
+    List<SurveySubmission> submissions = findSubmissionsForBundle(memberId, currentBundleId);
+
+    if (hasReachedSubmissionLimit(submissions)) {
+      return createNextBundleSurveyHistory(currentBundleId);
+    }
+    return createCurrentBundleSurveyHistory(currentBundleId, submissions);
+  }
+
+  private SurveySubmission findLatestSubmission(Long memberId) {
+    return surveySubmissionRepository
+        .findTopByMember_IdAndDeletedAtIsNullOrderByCreatedAtDesc(memberId)
+        .orElse(null);
+  }
+
+  private List<SurveySubmission> findSubmissionsForBundle(Long memberId, Long bundleId) {
+    return surveySubmissionRepository.findByMember_IdAndSurvey_SurveyBundle_Id(memberId, bundleId);
+  }
+
+  private boolean hasReachedSubmissionLimit(List<SurveySubmission> submissions) {
+    return submissions.size() >= DEFAULT_SIZE_OF_BUNDLE;
+  }
+
+  private SurveyHistoryResponse createInitialSurveyHistory() {
+    return new SurveyHistoryResponse(1L, List.of(), 1);
+  }
+
+  private SurveyHistoryResponse createNextBundleSurveyHistory(Long currentBundleId) {
+    return new SurveyHistoryResponse(currentBundleId + 1, List.of(), 1);
+  }
+
+  private SurveyHistoryResponse createCurrentBundleSurveyHistory(
+      Long bundleId, List<SurveySubmission> submissions) {
+    List<SurveyHistoryDetailResponse> historyDetails =
+        submissions.stream()
+            .map(submission -> new SurveyHistoryDetailResponse(submission.getId()))
+            .toList();
+
+    return new SurveyHistoryResponse(bundleId, historyDetails, submissions.size() + 1);
   }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -2,6 +2,7 @@ package org.nexters.jaknaesocore.domain.survey.service;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryDetailResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
@@ -50,7 +51,12 @@ public class SurveyService {
     List<SurveySubmission> submissions = findSubmissionsForBundle(memberId, currentBundleId);
 
     if (bundle.isAllSubmitted(submissions)) {
-      return createNextBundleSurveyHistory(currentBundleId);
+      Long nextBundleId =
+          surveyBundleRepository
+              .findFirstByIdGreaterThanOrderByIdAsc(currentBundleId)
+              .map(SurveyBundle::getId)
+              .orElseThrow(() -> CustomException.NOT_READY_FOR_NEXT_BUNDLE);
+      return createNextBundleSurveyHistory(nextBundleId);
     }
     return createCurrentBundleSurveyHistory(currentBundleId, submissions);
   }
@@ -70,8 +76,8 @@ public class SurveyService {
     return new SurveyHistoryResponse(1L, List.of(), 1);
   }
 
-  private SurveyHistoryResponse createNextBundleSurveyHistory(final Long currentBundleId) {
-    return new SurveyHistoryResponse(currentBundleId + 1, List.of(), 1);
+  private SurveyHistoryResponse createNextBundleSurveyHistory(final Long bundleId) {
+    return new SurveyHistoryResponse(bundleId, List.of(), 1);
   }
 
   private SurveyHistoryResponse createCurrentBundleSurveyHistory(

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
@@ -50,6 +50,52 @@ class SurveyBundleTest {
         .hasMessage("모든 설문을 완료하셨습니다.");
   }
 
+  @Test
+  void 모든_설문을_제출했는지_확인한다() {
+    // given
+    SurveyBundle surveyBundle = new SurveyBundle();
+
+    BalanceSurvey survey1 = createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+    BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+    MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+    MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+
+    surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+
+    SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
+
+    SurveySubmission submission2 = SurveySubmission.builder().survey(survey2).build();
+
+    SurveySubmission submission3 = SurveySubmission.builder().survey(survey3).build();
+
+    SurveySubmission submission4 = SurveySubmission.builder().survey(survey4).build();
+
+    // when
+    boolean result =
+        surveyBundle.isAllSubmitted(List.of(submission1, submission2, submission3, submission4));
+    // then
+    then(result).isTrue();
+  }
+
+  @Test
+  void 모든_설문을_제출했는지_확인한다2() {
+    // given
+    SurveyBundle surveyBundle = new SurveyBundle();
+
+    BalanceSurvey survey1 = createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+    BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+    MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+    MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+
+    surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+
+    SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
+    // when
+    boolean result = surveyBundle.isAllSubmitted(List.of(submission1));
+    // then
+    then(result).isFalse();
+  }
+
   private BalanceSurvey createBalanceSurvey(String content, SurveyBundle surveyBundle, Long id) {
     BalanceSurvey survey = new BalanceSurvey(content, surveyBundle);
     ReflectionTestUtils.setField(survey, "id", id);

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -50,50 +51,70 @@ class SurveyBundleTest {
         .hasMessage("모든 설문을 완료하셨습니다.");
   }
 
-  @Test
-  void 모든_설문을_제출했는지_확인한다() {
-    // given
-    SurveyBundle surveyBundle = new SurveyBundle();
+  @Nested
+  @DisplayName("isAllSubmitted 메서드는")
+  class isAllSubmitted {
 
-    BalanceSurvey survey1 = createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
-    BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
-    MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
-    MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+    @Nested
+    @DisplayName("모든 설문을 제출한 경우")
+    class whenAllSubmitted {
 
-    surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+      @DisplayName("true를 반환한다.")
+      @Test
+      void 모든_설문을_제출했는지_확인한다() {
+        // given
+        SurveyBundle surveyBundle = new SurveyBundle();
 
-    SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
+        BalanceSurvey survey1 =
+            createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+        BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+        MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+        MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
 
-    SurveySubmission submission2 = SurveySubmission.builder().survey(survey2).build();
+        surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
 
-    SurveySubmission submission3 = SurveySubmission.builder().survey(survey3).build();
+        SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
 
-    SurveySubmission submission4 = SurveySubmission.builder().survey(survey4).build();
+        SurveySubmission submission2 = SurveySubmission.builder().survey(survey2).build();
 
-    // when
-    boolean result =
-        surveyBundle.isAllSubmitted(List.of(submission1, submission2, submission3, submission4));
-    // then
-    then(result).isTrue();
-  }
+        SurveySubmission submission3 = SurveySubmission.builder().survey(survey3).build();
 
-  @Test
-  void 모든_설문을_제출했는지_확인한다2() {
-    // given
-    SurveyBundle surveyBundle = new SurveyBundle();
+        SurveySubmission submission4 = SurveySubmission.builder().survey(survey4).build();
 
-    BalanceSurvey survey1 = createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
-    BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
-    MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
-    MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+        // when
+        boolean result =
+            surveyBundle.isAllSubmitted(
+                List.of(submission1, submission2, submission3, submission4));
+        // then
+        then(result).isTrue();
+      }
+    }
 
-    surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+    @DisplayName("모든 설문을 제출하지 않은 경우")
+    @Nested
+    class whenNotAllSubmitted {
 
-    SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
-    // when
-    boolean result = surveyBundle.isAllSubmitted(List.of(submission1));
-    // then
-    then(result).isFalse();
+      @DisplayName("false를 반환한다.")
+      @Test
+      void 모든_설문을_제출했는지_확인한다() {
+        // given
+        SurveyBundle surveyBundle = new SurveyBundle();
+
+        BalanceSurvey survey1 =
+            createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+        BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+        MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+        MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+
+        surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+
+        SurveySubmission submission1 = SurveySubmission.builder().survey(survey1).build();
+        // when
+        boolean result = surveyBundle.isAllSubmitted(List.of(submission1));
+        // then
+        then(result).isFalse();
+      }
+    }
   }
 
   private BalanceSurvey createBalanceSurvey(String content, SurveyBundle surveyBundle, Long id) {

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepositoryTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepositoryTest.java
@@ -1,0 +1,57 @@
+package org.nexters.jaknaesocore.domain.survey.repository;
+
+import static org.assertj.core.api.BDDAssertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.nexters.jaknaesocore.common.support.IntegrationTest;
+import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class SurveyBundleRepositoryTest extends IntegrationTest {
+
+  @Autowired private SurveyBundleRepository surveyBundleRepository;
+
+  @AfterEach
+  void tearDown() {
+    surveyBundleRepository.deleteAllInBatch();
+  }
+
+  @Test
+  void 주어진_ID_보다_큰_번들_중_가장_작은_ID를_가진_번들을_찾는다() {
+    // given
+    SurveyBundle surveyBundle1 = new SurveyBundle();
+    SurveyBundle surveyBundle2 = new SurveyBundle();
+    SurveyBundle surveyBundle3 = new SurveyBundle();
+    SurveyBundle surveyBundle4 = new SurveyBundle();
+
+    surveyBundleRepository.saveAll(
+        List.of(surveyBundle1, surveyBundle2, surveyBundle3, surveyBundle4));
+    // when
+    Optional<SurveyBundle> result =
+        surveyBundleRepository.findFirstByIdGreaterThanOrderByIdAsc(surveyBundle2.getId());
+    // then
+    then(result)
+        .hasValueSatisfying(
+            surveyBundle -> then(surveyBundle.getId()).isEqualTo(surveyBundle3.getId()));
+  }
+
+  @Test
+  void 주어진_ID보다_큰_번들이_없으면_빈_값을_반환한다() {
+    // given
+    SurveyBundle surveyBundle1 = new SurveyBundle();
+    SurveyBundle surveyBundle2 = new SurveyBundle();
+    SurveyBundle surveyBundle3 = new SurveyBundle();
+    SurveyBundle surveyBundle4 = new SurveyBundle();
+
+    surveyBundleRepository.saveAll(
+        List.of(surveyBundle1, surveyBundle2, surveyBundle3, surveyBundle4));
+    // when
+    Optional<SurveyBundle> result = surveyBundleRepository.findFirstByIdGreaterThanOrderByIdAsc(4L);
+    // then
+    then(result).isEmpty();
+  }
+}

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepositoryTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepositoryTest.java
@@ -2,8 +2,10 @@ package org.nexters.jaknaesocore.domain.survey.repository;
 
 import static org.assertj.core.api.BDDAssertions.*;
 
+import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,11 +26,11 @@ class SurveySubmissionRepositoryTest extends IntegrationTest {
 
   @AfterEach
   void tearDown() {
-    surveySubmissionRepository.deleteAll();
-    surveyOptionRepository.deleteAll();
-    surveyRepository.deleteAll();
-    surveyBundleRepository.deleteAll();
-    memberRepository.deleteAll();
+    surveySubmissionRepository.deleteAllInBatch();
+    surveyOptionRepository.deleteAllInBatch();
+    surveyRepository.deleteAllInBatch();
+    surveyBundleRepository.deleteAllInBatch();
+    memberRepository.deleteAllInBatch();
   }
 
   @DisplayName("회원이 제출한 설문 ID를 가져온다.")
@@ -62,5 +64,101 @@ class SurveySubmissionRepositoryTest extends IntegrationTest {
         .hasSize(1)
         .extracting("id", "deletedAt")
         .containsExactly(tuple(surveySubmission.getId(), null));
+  }
+
+  @Transactional
+  @Test
+  void 회원이_제출한_가장_마지막_설문을_조회한다() {
+    // given
+    Member member = Member.create();
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+    surveyBundleRepository.save(surveyBundle);
+    BalanceSurvey survey1 = new BalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle);
+    BalanceSurvey survey2 = new BalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle);
+    MultipleChoiceSurvey survey3 = new MultipleChoiceSurvey("나의 행복 지수는", surveyBundle);
+    MultipleChoiceSurvey survey4 = new MultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("한다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("안한다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("한다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("안한다.").build();
+    SurveyOption option5 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("3점").build();
+    SurveyOption option6 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4, option5, option6));
+
+    SurveySubmission submission1 =
+        SurveySubmission.builder().member(member).selectedOption(option1).survey(survey1).build();
+    SurveySubmission submission2 =
+        SurveySubmission.builder().member(member).selectedOption(option4).survey(survey2).build();
+    surveySubmissionRepository.save(submission1);
+    surveySubmissionRepository.save(submission2);
+
+    // when
+    Optional<SurveySubmission> latestSubmission =
+        surveySubmissionRepository.findTopByMember_IdAndDeletedAtIsNullOrderByCreatedAtDesc(
+            member.getId());
+    // then
+    then(latestSubmission).isPresent();
+    then(latestSubmission.get())
+        .extracting("id", "survey.surveyBundle.id")
+        .containsExactly(submission2.getId(), surveyBundle.getId());
+  }
+
+  @Test
+  void 번들에서_제출한_설문을_조회한다() {
+    // given
+    Member member = Member.create();
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+    surveyBundleRepository.save(surveyBundle);
+    BalanceSurvey survey1 = new BalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle);
+    BalanceSurvey survey2 = new BalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle);
+    MultipleChoiceSurvey survey3 = new MultipleChoiceSurvey("나의 행복 지수는", surveyBundle);
+    MultipleChoiceSurvey survey4 = new MultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("한다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("안한다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("한다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("안한다.").build();
+    SurveyOption option5 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("3점").build();
+    SurveyOption option6 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4, option5, option6));
+
+    SurveySubmission submission1 =
+        SurveySubmission.builder().member(member).selectedOption(option1).survey(survey1).build();
+    SurveySubmission submission2 =
+        SurveySubmission.builder().member(member).selectedOption(option4).survey(survey2).build();
+    surveySubmissionRepository.save(submission1);
+    surveySubmissionRepository.save(submission2);
+
+    // then
+    then(surveySubmissionRepository.findByMember_IdAndSurvey_SurveyBundle_Id(
+            member.getId(), surveyBundle.getId()))
+        .hasSize(2)
+        .extracting("id")
+        .containsExactly(submission1.getId(), submission2.getId());
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.Test;
 import org.nexters.jaknaesocore.common.support.IntegrationTest;
 import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
 import org.nexters.jaknaesocore.domain.survey.model.*;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyBundleRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyOptionRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyRepository;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveySubmissionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
 class SurveyServiceTest extends IntegrationTest {
@@ -24,13 +26,15 @@ class SurveyServiceTest extends IntegrationTest {
   @Autowired private SurveyBundleRepository surveyBundleRepository;
   @Autowired private SurveyRepository surveyRepository;
   @Autowired private SurveyOptionRepository surveyOptionRepository;
+  @Autowired private SurveySubmissionRepository surveySubmissionRepository;
 
   @AfterEach
   void tearDown() {
-    surveyOptionRepository.deleteAll();
-    surveyRepository.deleteAll();
-    surveyBundleRepository.deleteAll();
-    memberRepository.deleteAll();
+    surveySubmissionRepository.deleteAllInBatch();
+    surveyOptionRepository.deleteAllInBatch();
+    surveyRepository.deleteAllInBatch();
+    surveyBundleRepository.deleteAllInBatch();
+    memberRepository.deleteAllInBatch();
   }
 
   @DisplayName("설문을 조회한다.")
@@ -60,5 +64,93 @@ class SurveyServiceTest extends IntegrationTest {
     then(survey.options())
         .extracting("id", "optionContents")
         .containsExactly(tuple(option.getId(), "질문 옵션 내용"));
+  }
+
+  @Test
+  void 설문_기록이_없으면_1번_번들을_제공한다() {
+    // given
+    Member member = Member.create();
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+    surveyBundleRepository.save(surveyBundle);
+    BalanceSurvey survey1 = new BalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle);
+    BalanceSurvey survey2 = new BalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle);
+    MultipleChoiceSurvey survey3 = new MultipleChoiceSurvey("나의 행복 지수는", surveyBundle);
+    MultipleChoiceSurvey survey4 = new MultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("한다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("안한다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("한다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("안한다.").build();
+    SurveyOption option5 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("3점").build();
+    SurveyOption option6 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4, option5, option6));
+    // when
+    SurveyHistoryResponse response = surveyService.getSurveyHistory(member.getId());
+
+    // then
+    then(response)
+        .extracting("bundleId", "nextSurveyIndex", "surveyHistoryDetails")
+        .containsExactly(1L, 1, List.of());
+  }
+
+  @Test
+  void 설문_기록이_일정_개수_이하이면_기록과_함께_번들ID를_제공한다() {
+    // given
+    Member member = Member.create();
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+    surveyBundleRepository.save(surveyBundle);
+    BalanceSurvey survey1 = new BalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle);
+    BalanceSurvey survey2 = new BalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle);
+    MultipleChoiceSurvey survey3 = new MultipleChoiceSurvey("나의 행복 지수는", surveyBundle);
+    MultipleChoiceSurvey survey4 = new MultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("한다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("안한다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("한다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("안한다.").build();
+    SurveyOption option5 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("3점").build();
+    SurveyOption option6 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4, option5, option6));
+
+    SurveySubmission submission1 =
+        SurveySubmission.builder().member(member).selectedOption(option1).survey(survey1).build();
+    SurveySubmission submission2 =
+        SurveySubmission.builder().member(member).selectedOption(option4).survey(survey2).build();
+    surveySubmissionRepository.save(submission1);
+    surveySubmissionRepository.save(submission2);
+    // when
+    SurveyHistoryResponse response = surveyService.getSurveyHistory(member.getId());
+    // then
+    then(response)
+        .extracting("bundleId", "nextSurveyIndex")
+        .containsExactly(surveyBundle.getId(), 3);
+
+    then(response.surveyHistoryDetails())
+        .extracting("submissionId")
+        .containsExactly(submission1.getId(), submission2.getId());
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -153,4 +153,56 @@ class SurveyServiceTest extends IntegrationTest {
         .extracting("submissionId")
         .containsExactly(submission1.getId(), submission2.getId());
   }
+
+  @Test
+  void 설문_기록이_번들_크기만큼_있으면_다음_번들ID를_제공한다() {
+    // given
+    Member member = Member.create();
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+    surveyBundleRepository.save(surveyBundle);
+
+    BalanceSurvey survey1 = new BalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle);
+    BalanceSurvey survey2 = new BalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle);
+    MultipleChoiceSurvey survey3 = new MultipleChoiceSurvey("나의 행복 지수는", surveyBundle);
+    MultipleChoiceSurvey survey4 = new MultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("한다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("한다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("3점").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
+
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4));
+
+    // 모든 설문에 대한 제출 생성
+    SurveySubmission submission1 =
+        SurveySubmission.builder().member(member).selectedOption(option1).survey(survey1).build();
+    SurveySubmission submission2 =
+        SurveySubmission.builder().member(member).selectedOption(option2).survey(survey2).build();
+    SurveySubmission submission3 =
+        SurveySubmission.builder().member(member).selectedOption(option3).survey(survey3).build();
+    SurveySubmission submission4 =
+        SurveySubmission.builder().member(member).selectedOption(option4).survey(survey4).build();
+
+    surveySubmissionRepository.saveAll(List.of(submission1, submission2, submission3, submission4));
+
+    // when
+    SurveyHistoryResponse response = surveyService.getSurveyHistory(member.getId());
+
+    // then
+    then(response)
+        .extracting("bundleId", "nextSurveyIndex", "surveyHistoryDetails")
+        .containsExactly(surveyBundle.getId() + 1L, 1, List.of());
+  }
 }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -2,6 +2,7 @@ package org.nexters.jaknaesoserver.domain.survey.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesocore.common.support.response.ApiResponse;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
 import org.nexters.jaknaesocore.domain.survey.service.SurveyService;
 import org.nexters.jaknaesoserver.domain.auth.model.CustomUserDetails;
@@ -22,5 +23,11 @@ public class SurveyController {
   public ApiResponse<SurveyResponse> getNextSurvey(
       @AuthenticationPrincipal CustomUserDetails member, @PathVariable Long bundleId) {
     return ApiResponse.success(surveyService.getNextSurvey(bundleId, member.getMemberId()));
+  }
+
+  @GetMapping("/history")
+  public ApiResponse<SurveyHistoryResponse> getSurveyHistory(
+      @AuthenticationPrincipal CustomUserDetails member) {
+    return ApiResponse.success(surveyService.getSurveyHistory(member.getMemberId()));
   }
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
@@ -16,6 +16,8 @@ import com.epages.restdocs.apispec.SimpleType;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryDetailResponse;
+import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyOptionsResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
 import org.nexters.jaknaesoserver.common.support.ControllerTest;
@@ -73,6 +75,44 @@ class SurveyControllerTest extends ControllerTest {
                                 .description("설문지 옵션 내용"),
                             fieldWithPath("error").description("에러").optional())
                         .responseSchema(Schema.schema("surveyResponse"))
+                        .build())));
+  }
+
+  @WithMockCustomUser
+  @DisplayName("회원의 설문 이력을 가져온다.")
+  @Test
+  void getSurveyHistory() throws Exception {
+    SurveyHistoryResponse response =
+        new SurveyHistoryResponse(
+            1L,
+            List.of(new SurveyHistoryDetailResponse(1L), new SurveyHistoryDetailResponse(2L)),
+            3);
+
+    given(surveyService.getSurveyHistory(anyLong())).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/surveys/history").with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "survey-get-history",
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("회원의 설문 이력을 조회")
+                        .tag("Survey Domain")
+                        .responseFields(
+                            fieldWithPath("result").type(SimpleType.STRING).description("결과"),
+                            fieldWithPath("data.bundleId")
+                                .type(SimpleType.NUMBER)
+                                .description("번들 ID"),
+                            fieldWithPath("data.surveyHistoryDetails[].submissionId")
+                                .type(SimpleType.NUMBER)
+                                .description("제출 ID"),
+                            fieldWithPath("data.nextSurveyIndex")
+                                .type(SimpleType.NUMBER)
+                                .description("다음 설문 인덱스"),
+                            fieldWithPath("error").description("에러").optional())
+                        .responseSchema(Schema.schema("surveyHistoryResponse"))
                         .build())));
   }
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
현재 진행중인 질문 목록 조회 API 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 번들을 AutoIncrement하게 뽑도록 구현하였습니다.
- 최초진입시 1번 번들을 이용하게 하였습니다.
- 번들의 Size인 15가 넘으면 새로운 번들을 받을 수 있도록 하였습니다.
- `BaseTimeEntity`에 `AuditingListener`가 적용되어있지 않아서 시간이 들어가고있지 않아서 추가하였습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
### 테스트에서 `@Transactional` 사용
- 지금 `회원이_제출한_가장_마지막_설문을_조회한다` 에서 `@Transactional`을 사용하고 있는데 사용하지 않으면 테스트에서 지연로딩을 활용한 테스트를 할 수 없어서 사용하였는데 이 경우에는 어떻게 하는게 좋을지 의견있으시면 주시면 감사하겠습니다.

해당 메서드를 통해서 `bundleId`를 검증하려고 하는게 테스트하면서 욕심인건지..? 궁금합니다.

네이밍 쿼리 이렇게 사용해도 괜찮은지도 알려주시면 감사하겠습니다 !

### 남은 작업
- [x] 기록이 15개 일 경우 다음 번들로 넘어가는 테스트 작성 