### PR TITLE
Feat(#36): 회원 조회 API

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/member/service/MemberService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/member/service/MemberService.java
@@ -3,6 +3,7 @@ package org.nexters.jaknaesocore.domain.member.service;
 import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
+import org.nexters.jaknaesocore.domain.member.service.dto.MemberResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,7 +15,13 @@ public class MemberService {
 
   @Transactional
   public void deleteMember(final Long memberId) {
-    Member member = memberRepository.findMember(memberId);
+    final Member member = memberRepository.findMember(memberId);
     member.softDelete();
+  }
+
+  @Transactional(readOnly = true)
+  public MemberResponse getMember(final Long memberId) {
+    final Member member = memberRepository.findMember(memberId);
+    return MemberResponse.of(member);
   }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/member/service/dto/MemberResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/member/service/dto/MemberResponse.java
@@ -1,0 +1,10 @@
+package org.nexters.jaknaesocore.domain.member.service.dto;
+
+import org.nexters.jaknaesocore.domain.member.model.Member;
+
+public record MemberResponse(String name, String email) {
+
+  public static MemberResponse of(final Member member) {
+    return new MemberResponse(member.getName(), member.getEmail());
+  }
+}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/member/controller/MemberController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/member/controller/MemberController.java
@@ -4,10 +4,12 @@ import java.nio.file.AccessDeniedException;
 import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesocore.common.support.response.ApiResponse;
 import org.nexters.jaknaesocore.domain.member.service.MemberService;
+import org.nexters.jaknaesocore.domain.member.service.dto.MemberResponse;
 import org.nexters.jaknaesoserver.domain.auth.model.CustomUserDetails;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -30,5 +32,11 @@ public class MemberController {
     }
     memberService.deleteMember(memberId);
     return ApiResponse.success();
+  }
+
+  @GetMapping("/{memberId}")
+  public ApiResponse<MemberResponse> getMember(@PathVariable Long memberId) {
+    MemberResponse response = memberService.getMember(memberId);
+    return ApiResponse.success(response);
   }
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
@@ -1,20 +1,23 @@
 package org.nexters.jaknaesoserver.domain.member.controller;
 
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.mockito.BDDMockito.willThrow;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
 import org.junit.jupiter.api.Test;
-import org.nexters.jaknaesocore.common.support.error.CustomException;
-import org.nexters.jaknaesocore.common.support.error.ErrorType;
+import org.nexters.jaknaesocore.domain.member.service.dto.MemberResponse;
 import org.nexters.jaknaesoserver.common.support.ControllerTest;
 import org.nexters.jaknaesoserver.common.support.WithMockCustomUser;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 class MemberControllerTest extends ControllerTest {
 
@@ -32,7 +35,7 @@ class MemberControllerTest extends ControllerTest {
                 .with(csrf()))
         .andExpect(status().isNoContent())
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
+            document(
                 "delete-member-success",
                 resource(
                     ResourceSnippetParameters.builder()
@@ -43,47 +46,34 @@ class MemberControllerTest extends ControllerTest {
 
   @WithMockCustomUser
   @Test
-  void 아이디에_해당하는_멤버가_존재하지_않아_404_얘외를_반환한다() throws Exception {
+  void 회원_정보를_조회한다() throws Exception {
 
-    willThrow(new CustomException(ErrorType.MEMBER_NOT_FOUND))
-        .given(memberService)
-        .deleteMember(1L);
+    given(memberService.getMember(1L)).willReturn(new MemberResponse("홍길동", "test@example.com"));
 
     mockMvc
         .perform(
-            delete("/api/v1/members/1")
+            MockMvcRequestBuilders.get("/api/v1/members/1")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))
-        .andExpect(status().isNotFound())
+        .andExpect(status().isOk())
         .andDo(
-            MockMvcRestDocumentationWrapper.document(
-                "delete-member-fail",
+            document(
+                "get-member-success",
                 resource(
                     ResourceSnippetParameters.builder()
-                        .description("회원 탈퇴")
+                        .description("회원 정보 조회")
                         .tags("Member Domain")
-                        .build())));
-  }
-
-  @WithMockCustomUser(userId = 1)
-  @Test
-  void 본인_계정이_아닌_계정을_삭제하려고_하면_예외를_반환한다() throws Exception {
-
-    mockMvc
-        .perform(
-            delete("/api/v1/members/2")
-                .accept(APPLICATION_JSON)
-                .contentType(APPLICATION_JSON)
-                .with(csrf()))
-        .andExpect(status().is4xxClientError())
-        .andDo(
-            MockMvcRestDocumentationWrapper.document(
-                "delete-member-fail",
-                resource(
-                    ResourceSnippetParameters.builder()
-                        .description("회원 탈퇴")
-                        .tags("Member Domain")
+                        .responseFields(
+                            fieldWithPath("result")
+                                .type(SimpleType.STRING)
+                                .description("API 요청 결과 (성공/실패)"),
+                            fieldWithPath("data.name").type(SimpleType.STRING).description("회원 이름"),
+                            fieldWithPath("data.email")
+                                .type(SimpleType.STRING)
+                                .description("회원 이메일"),
+                            fieldWithPath("error").description("에러").optional())
+                        .responseSchema(schema("MemberResponse"))
                         .build())));
   }
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
회원 조회 API 작성

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 회원 정보를 조회하기 위한 컨트롤러, 서비스, dto 작성

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- #52 에 이어서 작업해서 base 브랜치를 feature 브랜치로 연결해놓았습니다.
- 이전에 `@Transactional` 관련 포스팅을 추천해주셨는데 `@Transactional(readOnly=true)`를 삭제하는 것이 좋을까요? 읽기 쿼리 한 번 날리는 거라 트랜잭션을 걸지 않아도 될 것 같습니다.