### PR TITLE
Feat(#60) 질문 제공 방식 순차방식 구현

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -23,6 +23,8 @@ public class CustomException extends RuntimeException {
       new CustomException(ErrorType.SURVEY_NOT_FOUND);
   public static final CustomException NOT_READY_FOR_NEXT_BUNDLE =
       new CustomException(ErrorType.NOT_READY_FOR_NEXT_BUNDLE);
+  public static final CustomException ALREADY_COMPLETED_SURVEY_BUNDLE =
+      new CustomException(ErrorType.ALREADY_COMPLETED_SURVEY_BUNDLE);
 
   private final ErrorType errorType;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
@@ -42,6 +42,9 @@ public enum ErrorType {
   // survey
   NOT_READY_FOR_NEXT_BUNDLE(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "다음 번들을 진행할 준비가 되지 않았습니다.", LogLevel.WARN),
+
+  ALREADY_COMPLETED_SURVEY_BUNDLE(
+      HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 완료된 설문 번들입니다.", LogLevel.WARN),
   ;
 
   private final HttpStatus status;

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundle.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundle.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.nexters.jaknaesocore.common.model.BaseTimeEntity;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
 
 @Getter
 @NoArgsConstructor
@@ -27,10 +28,20 @@ public class SurveyBundle extends BaseTimeEntity {
         surveys.stream().filter(survey -> !submittedSurvey.contains(survey)).toList();
 
     if (list.isEmpty()) {
-      throw new IllegalStateException("모든 설문을 완료하셨습니다.");
+      throw CustomException.ALREADY_COMPLETED_SURVEY_BUNDLE;
     }
     int randomNum = ThreadLocalRandom.current().nextInt(list.size());
     return list.get(randomNum);
+  }
+
+  public Survey getNextSurvey(final List<Survey> submittedSurvey) {
+    List<Survey> list =
+        surveys.stream().filter(survey -> !submittedSurvey.contains(survey)).toList();
+
+    if (list.isEmpty()) {
+      throw CustomException.ALREADY_COMPLETED_SURVEY_BUNDLE;
+    }
+    return list.getFirst();
   }
 
   public boolean isAllSubmitted(final List<SurveySubmission> submissions) {

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -32,9 +32,9 @@ public class SurveyService {
             .findById(bundleId)
             .orElseThrow(() -> new IllegalArgumentException("설문 번들을 찾을 수 없습니다."));
     List<Survey> submittedSurvey = getSubmittedSurvey(memberId);
-    Survey unSubmittedSurvey = bundle.getUnSubmittedSurvey(submittedSurvey);
+    Survey nextSurvey = bundle.getNextSurvey(submittedSurvey);
 
-    return SurveyResponse.of(unSubmittedSurvey);
+    return SurveyResponse.of(nextSurvey);
   }
 
   private List<Survey> getSubmittedSurvey(final Long memberId) {

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveyBundleTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 class SurveyBundleTest {
@@ -47,8 +48,7 @@ class SurveyBundleTest {
     // when & then
     thenThrownBy(
             () -> surveyBundle.getUnSubmittedSurvey(List.of(survey1, survey2, survey3, survey4)))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("모든 설문을 완료하셨습니다.");
+        .isEqualTo(CustomException.ALREADY_COMPLETED_SURVEY_BUNDLE);
   }
 
   @Nested
@@ -113,6 +113,57 @@ class SurveyBundleTest {
         boolean result = surveyBundle.isAllSubmitted(List.of(submission1));
         // then
         then(result).isFalse();
+      }
+    }
+  }
+
+  @DisplayName("getNextSurvey 메서드는")
+  @Nested
+  class getNextSurvey {
+    @DisplayName("번들의 모든 설문을 제출한 경우")
+    @Nested
+    class whenAllSubmitted {
+      @DisplayName("예외를 던진다.")
+      @Test
+      void 모든_설문을_제출했을_때_다음_설문을_가져오려고_할_때() {
+        // given
+        SurveyBundle surveyBundle = new SurveyBundle();
+
+        BalanceSurvey survey1 =
+            createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+        BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+        MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+        MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+
+        surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+
+        // when
+        // then
+        thenThrownBy(() -> surveyBundle.getNextSurvey(List.of(survey1, survey2, survey3, survey4)))
+            .isEqualTo(CustomException.ALREADY_COMPLETED_SURVEY_BUNDLE);
+      }
+    }
+
+    @DisplayName("번들의 모든 설문을 제출하지 않은 경우")
+    @Nested
+    class whenNotAllSubmitted {
+      @Test
+      void 번들_내부의_설문_중_제출하지않은_다음_설문을_가져온다() {
+        // given
+        SurveyBundle surveyBundle = new SurveyBundle();
+
+        BalanceSurvey survey1 =
+            createBalanceSurvey("대학 동기 모임에서 나의 승진 이야기가 나왔습니다", surveyBundle, 1L);
+        BalanceSurvey survey2 = createBalanceSurvey("회사에서 팀 리더로 뽑혔습니다", surveyBundle, 2L);
+        MultipleChoiceSurvey survey3 = createMultipleChoiceSurvey("나의 행복 지수는", surveyBundle, 3L);
+        MultipleChoiceSurvey survey4 = createMultipleChoiceSurvey("나는 노는게 좋다.", surveyBundle, 4L);
+
+        surveyBundle.getSurveys().addAll(List.of(survey1, survey2, survey3, survey4));
+        // when
+        Survey nextSurvey = surveyBundle.getNextSurvey(List.of(survey1, survey2));
+
+        // then
+        then(nextSurvey).extracting("id", "content").containsExactly(3L, "나의 행복 지수는");
       }
     }
   }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -55,14 +55,19 @@ class SurveyServiceTest extends IntegrationTest {
     SurveyBundle surveyBundle = new SurveyBundle();
     surveyBundleRepository.save(surveyBundle);
     BalanceSurvey balanceSurvey = new BalanceSurvey("질문내용", surveyBundle);
-    surveyRepository.save(balanceSurvey);
+    MultipleChoiceSurvey multipleSurvey = new MultipleChoiceSurvey("다음 질문내용", surveyBundle);
+    surveyRepository.saveAll(List.of(balanceSurvey, multipleSurvey));
     List<KeywordScore> scores =
         List.of(
             KeywordScore.builder().keyword(Keyword.ACHIEVEMENT).score(BigDecimal.ONE).build(),
             KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
     SurveyOption option =
         SurveyOption.builder().survey(balanceSurvey).scores(scores).content("질문 옵션 내용").build();
-    surveyOptionRepository.save(option);
+    SurveyOption multipleOption1 =
+        SurveyOption.builder().survey(multipleSurvey).scores(scores).content("1점").build();
+    SurveyOption multipleOption2 =
+        SurveyOption.builder().survey(multipleSurvey).scores(scores).content("2점").build();
+    surveyOptionRepository.saveAll(List.of(option, multipleOption1, multipleOption2));
 
     // when
     SurveyResponse survey = surveyService.getNextSurvey(surveyBundle.getId(), member.getId());


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 정책이 변경됨에 따라 랜덤이 아닌 순차방식으로 다음 질문을 가져오도록 변경

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 번들 내의 제출하지 않은 질문 중 다음질문을 가져오도록 변경하였습니다.

## 고민 사항
한번 이야기 나왔던 사항 같은데 질문을 조회 할 때 백엔드 단에서도 금일 제출한 내역이 존재한다면 조회를 막는게 좋을 지 아니면 논의가 된 대로 API 호출이 불가한 상태이니 현재 상태 유지하는게 좋을 지 이야기 해보면 좋을 것 같습니다