### PR TITLE
Fix(#68): CD 빌드 시간 개선

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,7 +34,7 @@ jobs:
         id: ip
         run: |
           PUBLIC_IP=$(curl -s https://ifconfig.me)
-          echo "::set-output name=public_ip::$PUBLIC_IP"
+          echo "PUBLIC_IP=$PUBLIC_IP" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -52,12 +52,12 @@ jobs:
           context: .
           file: ./jaknaeso-server/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: |
             ${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME }}:${{ env.BUILD_NUMBER }}
             ${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME }}:latest
-          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:latest
-          cache-to: type=inline
+          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache,image-manifest=true,oci-mediatypes=true
+          cache-to: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
 
       - name: Setting NCP CLI & Credentials
         run: |
@@ -73,8 +73,8 @@ jobs:
           cd ~/cli_linux
           ./ncloud vserver addAccessControlGroupInboundRule \
             --regionCode KR --vpcNo ${{ env.NCP_VPC_ID }} \
-            --accessControlGroupNo ${{ secrets.NCP_AGC_ID }} \
-            --accessControlGroupRuleList "protocolTypeCode='TCP', ipBlock='${{ steps.ip.outputs.public_ip }}/32', portRange='22'" > /dev/null 2>&1
+            --accessControlGroupNo ${{ env.NCP_AGC_ID }} \
+            --accessControlGroupRuleList "protocolTypeCode='TCP', ipBlock='${{ env.PUBLIC_IP }}/32', portRange='22'" > /dev/null 2>&1
 
       - name: Create .env file
         run: |
@@ -111,7 +111,7 @@ jobs:
             docker login ${{ env.REGISTRY_URL }} -u ${{ env.NCP_ACCESS_KEY }} -p ${{ env.NCP_SECRET_KEY }}
 
             docker-compose -f ~/docker-compose.yml pull
-            docker-compose -f ~/docker-compose.yml up -d
+            docker-compose -f ~/docker-compose.yml up -d --remove-orphans
             docker-compose exec nginx nginx -s reload
             
             chmod +x ~/scripts/server/register-certbot-cron-job.sh
@@ -125,4 +125,4 @@ jobs:
           ./ncloud vserver removeAccessControlGroupInboundRule \
             --regionCode KR --vpcNo ${{ env.NCP_VPC_ID }} \
             --accessControlGroupNo ${{ env.NCP_AGC_ID }} \
-            --accessControlGroupRuleList "protocolTypeCode='TCP', ipBlock='${{ steps.ip.outputs.public_ip }}/32', portRange='22'" > /dev/null 2>&1
+            --accessControlGroupRuleList "protocolTypeCode='TCP', ipBlock='${{ env.PUBLIC_IP }}/32', portRange='22'" > /dev/null 2>&1


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- CD 빌드 시간 단축 (기존 소요시간 10분 오버)
## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- registry 캐시 사용
- 단일 플랫폼 빌드
- set-output 사용 제외

## 문제점
기존 구성에서 멀티플랫폼으로 빌드해서 문제였던 것 같습니다. 제가 로컬에서 확인해본다고 arm64를 추가해뒀는데 제외했어야되는데 오래걸린 로그보니 arm64 이미지 빌드할 때 시간이 오래걸렸습니다.

제거하고 배포환경인 amd64만 이미지 빌드하도록 하였습니다.

## 현재 빌드 속도
- 최초 캐시용 이미지 생성 90s 소요
- 캐시 미스시 100s 가량 소요
- 캐시 히트시 17s 소요
---
## 참고
[Github Actions 사용 시 docker build 속도 높이기](https://velog.io/@leejh3224/Github-Actions-%EC%82%AC%EC%9A%A9-%EC%8B%9C-docker-build-%EC%86%8D%EB%8F%84-%EB%86%92%EC%9D%B4%EA%B8%B0)

해당 내용은 ECR이지만 동일하게 클라우드레지스트리에 적용가능할 것 같아서 캐싱적용했습니다.