### PR TITLE
Feat(#25): 답변 목록 조회 API 구현

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -25,6 +25,7 @@ public class CustomException extends RuntimeException {
       new CustomException(ErrorType.NOT_READY_FOR_NEXT_BUNDLE);
   public static final CustomException ALREADY_COMPLETED_SURVEY_BUNDLE =
       new CustomException(ErrorType.ALREADY_COMPLETED_SURVEY_BUNDLE);
+  public static final CustomException FORBIDDEN_ACCESS = new CustomException(ErrorType.FORBIDDEN);
 
   private final ErrorType errorType;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveySubmissionHistoryCommand.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveySubmissionHistoryCommand.java
@@ -1,0 +1,6 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+import lombok.Builder;
+
+@Builder
+public record SurveySubmissionHistoryCommand(Long memberId, Long bundleId) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveySubmissionHistoryResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveySubmissionHistoryResponse.java
@@ -1,0 +1,6 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+import java.util.List;
+import org.nexters.jaknaesocore.domain.survey.model.SurveyRecord;
+
+public record SurveySubmissionHistoryResponse(List<SurveyRecord> surveyRecords) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SubmittedAt.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SubmittedAt.java
@@ -1,0 +1,34 @@
+package org.nexters.jaknaesocore.domain.survey.model;
+
+import jakarta.persistence.Embeddable;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SubmittedAt {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  private LocalDateTime submittedAt;
+
+  @Builder
+  private SubmittedAt(LocalDateTime submittedAt) {
+    this.submittedAt = submittedAt;
+  }
+
+  String getYearMonthDay() {
+    return submittedAt.format(DATE_TIME_FORMATTER);
+  }
+
+  boolean isSubmittedByDate(LocalDate date) {
+    return date.equals(submittedAt.toLocalDate());
+  }
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyRecord.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyRecord.java
@@ -1,0 +1,20 @@
+package org.nexters.jaknaesocore.domain.survey.model;
+
+import java.time.format.DateTimeFormatter;
+import lombok.Builder;
+
+@Builder
+public record SurveyRecord(
+    String question, String answer, String retrospective, String submittedAt) {
+
+  private static final DateTimeFormatter DATE_TIME_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+  public static SurveyRecord of(SurveySubmission submission) {
+    String question = submission.getSurvey().getContent();
+    String answer = submission.getSelectedOption().getContent();
+    String retrospective = submission.getRetrospective();
+    String submittedAt = submission.getSubmittedAt().format(DATE_TIME_FORMATTER);
+    return new SurveyRecord(question, answer, retrospective, submittedAt);
+  }
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyRecord.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyRecord.java
@@ -1,20 +1,16 @@
 package org.nexters.jaknaesocore.domain.survey.model;
 
-import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 
 @Builder
 public record SurveyRecord(
     String question, String answer, String retrospective, String submittedAt) {
 
-  private static final DateTimeFormatter DATE_TIME_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy.MM.dd");
-
   public static SurveyRecord of(SurveySubmission submission) {
     String question = submission.getSurvey().getContent();
     String answer = submission.getSelectedOption().getContent();
     String retrospective = submission.getRetrospective();
-    String submittedAt = submission.getSubmittedAt().format(DATE_TIME_FORMATTER);
+    String submittedAt = submission.getYearMonthDay();
     return new SurveyRecord(question, answer, retrospective, submittedAt);
   }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmission.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmission.java
@@ -29,7 +29,7 @@ public class SurveySubmission extends BaseTimeEntity {
 
   private String retrospective;
 
-  private LocalDateTime submittedAt;
+  @Embedded private SubmittedAt submittedAt;
 
   @Builder
   private SurveySubmission(
@@ -42,7 +42,7 @@ public class SurveySubmission extends BaseTimeEntity {
     this.survey = survey;
     this.selectedOption = selectedOption;
     this.retrospective = retrospective;
-    this.submittedAt = submittedAt;
+    this.submittedAt = SubmittedAt.builder().submittedAt(submittedAt).build();
   }
 
   public static SurveySubmission create(
@@ -61,6 +61,14 @@ public class SurveySubmission extends BaseTimeEntity {
   }
 
   public boolean isSubmittedByDate(LocalDate date) {
-    return submittedAt.toLocalDate().isEqual(date);
+    return submittedAt.isSubmittedByDate(date);
+  }
+
+  public LocalDateTime getSubmittedAt() {
+    return submittedAt.getSubmittedAt();
+  }
+
+  public String getYearMonthDay() {
+    return submittedAt.getYearMonthDay();
   }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmission.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmission.java
@@ -32,7 +32,7 @@ public class SurveySubmission extends BaseTimeEntity {
   private LocalDateTime submittedAt;
 
   @Builder
-  public SurveySubmission(
+  private SurveySubmission(
       Member member,
       Survey survey,
       SurveyOption selectedOption,

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmissions.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmissions.java
@@ -5,7 +5,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class SurveySubscriptions {
+public class SurveySubmissions {
 
   private final List<SurveySubmission> submissions;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -3,6 +3,7 @@ package org.nexters.jaknaesocore.domain.survey.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -122,6 +123,7 @@ public class SurveyService {
     return surveySubmissionRepository
         .findByMember_IdAndSurvey_SurveyBundle_Id(command.memberId(), command.bundleId())
         .stream()
+        .sorted(Comparator.comparing(SurveySubmission::getSubmittedAt))
         .map(SurveyRecord::of)
         .collect(
             Collectors.collectingAndThen(

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -2,7 +2,6 @@ package org.nexters.jaknaesocore.domain.survey.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -23,8 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class SurveyService {
-
-  private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
 
   private final MemberRepository memberRepository;
   private final SurveyBundleRepository surveyBundleRepository;

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -43,7 +43,7 @@ public class SurveyService {
   private List<Survey> getSubmittedSurvey(final Long memberId) {
     List<SurveySubmission> surveySubmissionsByMember =
         surveySubmissionRepository.findByMember_IdAndDeletedAtIsNull(memberId);
-    return new SurveySubscriptions(surveySubmissionsByMember).getSubmittedSurvey(memberId);
+    return new SurveySubmissions(surveySubmissionsByMember).getSubmittedSurvey(memberId);
   }
 
   @Transactional(readOnly = true)

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -2,17 +2,16 @@ package org.nexters.jaknaesocore.domain.survey.service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesocore.common.model.BaseEntity;
 import org.nexters.jaknaesocore.common.support.error.CustomException;
 import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryDetailResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveySubmissionCommand;
+import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.model.*;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyBundleRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyRepository;
@@ -23,6 +22,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Service
 public class SurveyService {
+
+  private static final DateTimeFormatter MONTH_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM");
 
   private final MemberRepository memberRepository;
   private final SurveyBundleRepository surveyBundleRepository;
@@ -113,5 +114,17 @@ public class SurveyService {
         SurveySubmission.create(member, survey, surveyOption, command.comment(), submittedAt);
 
     surveySubmissionRepository.save(surveySubmission);
+  }
+
+  @Transactional(readOnly = true)
+  public SurveySubmissionHistoryResponse getSurveySubmissionHistory(
+      final SurveySubmissionHistoryCommand command) {
+    return surveySubmissionRepository
+        .findByMember_IdAndSurvey_SurveyBundle_Id(command.memberId(), command.bundleId())
+        .stream()
+        .map(SurveyRecord::of)
+        .collect(
+            Collectors.collectingAndThen(
+                Collectors.toList(), SurveySubmissionHistoryResponse::new));
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmissionsTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/model/SurveySubmissionsTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.springframework.test.util.ReflectionTestUtils;
 
-class SurveySubscriptionsTest {
+class SurveySubmissionsTest {
 
   @DisplayName("회원이 제출한 설문들을 가져온다")
   @Test
@@ -40,7 +40,7 @@ class SurveySubscriptionsTest {
         SurveySubmission.builder().member(member).selectedOption(option2).survey(survey2).build();
 
     // when
-    SurveySubscriptions subscriptions = new SurveySubscriptions(List.of(submission1, submission2));
+    SurveySubmissions subscriptions = new SurveySubmissions(List.of(submission1, submission2));
     List<Survey> submittedSurveys = subscriptions.getSubmittedSurvey(1L);
 
     // then
@@ -79,7 +79,7 @@ class SurveySubscriptionsTest {
         SurveySubmission.builder().member(member2).selectedOption(option2).survey(survey2).build();
 
     // when
-    SurveySubscriptions subscriptions = new SurveySubscriptions(List.of(submission1, submission2));
+    SurveySubmissions subscriptions = new SurveySubmissions(List.of(submission1, submission2));
     List<Survey> submittedSurveys = subscriptions.getSubmittedSurvey(1L);
 
     // then
@@ -94,7 +94,7 @@ class SurveySubscriptionsTest {
     ReflectionTestUtils.setField(member, "id", 1L);
 
     // when
-    SurveySubscriptions subscriptions = new SurveySubscriptions(List.of());
+    SurveySubmissions subscriptions = new SurveySubmissions(List.of());
     List<Survey> submittedSurveys = subscriptions.getSubmittedSurvey(1L);
 
     // then

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -3,6 +3,7 @@ package org.nexters.jaknaesoserver.domain.survey.controller;
 import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
 import org.nexters.jaknaesocore.common.support.response.ApiResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.service.SurveyService;
@@ -51,7 +52,12 @@ public class SurveyController {
 
   @GetMapping("/members/{memberId}/submissions")
   public ApiResponse<SurveySubmissionHistoryResponse> getSurveyHistoryByMemberId(
-      @RequestParam Long bundleId, @PathVariable Long memberId) {
+      @RequestParam Long bundleId,
+      @PathVariable Long memberId,
+      @AuthenticationPrincipal CustomUserDetails member) {
+    if (!member.getMemberId().equals(memberId)) {
+      throw CustomException.FORBIDDEN_ACCESS;
+    }
     SurveySubmissionHistoryCommand command =
         SurveySubmissionHistoryCommand.builder().bundleId(bundleId).memberId(memberId).build();
     return ApiResponse.success(surveyService.getSurveySubmissionHistory(command));

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -49,14 +49,11 @@ public class SurveyController {
     return ApiResponse.success();
   }
 
-  @GetMapping("/history/{bundleId}/submissions/{memberId}")
+  @GetMapping("/members/{memberId}/submissions")
   public ApiResponse<SurveySubmissionHistoryResponse> getSurveyHistoryByMemberId(
-      @PathVariable Long bundleId, @PathVariable Long memberId) {
+      @RequestParam Long bundleId, @PathVariable Long memberId) {
     SurveySubmissionHistoryCommand command =
         SurveySubmissionHistoryCommand.builder().bundleId(bundleId).memberId(memberId).build();
-    // BundleId 받아서 submissions를 그냥 가져오기
-    // submissions record 안에 들어가야 할 정보
-    // 번들 내에서 제출 회차, 제출 일자(연.월.일), 질문, 답변, 회고
     return ApiResponse.success(surveyService.getSurveySubmissionHistory(command));
   }
 }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -4,9 +4,7 @@ import jakarta.validation.Valid;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesocore.common.support.response.ApiResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveyHistoryResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveyResponse;
-import org.nexters.jaknaesocore.domain.survey.dto.SurveySubmissionCommand;
+import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.service.SurveyService;
 import org.nexters.jaknaesoserver.domain.auth.model.CustomUserDetails;
 import org.nexters.jaknaesoserver.domain.survey.controller.dto.SurveySubmissionRequest;
@@ -49,5 +47,16 @@ public class SurveyController {
             .build();
     surveyService.submitSurvey(command, submittedAt);
     return ApiResponse.success();
+  }
+
+  @GetMapping("/history/{bundleId}/submissions/{memberId}")
+  public ApiResponse<SurveySubmissionHistoryResponse> getSurveyHistoryByMemberId(
+      @PathVariable Long bundleId, @PathVariable Long memberId) {
+    SurveySubmissionHistoryCommand command =
+        SurveySubmissionHistoryCommand.builder().bundleId(bundleId).memberId(memberId).build();
+    // BundleId 받아서 submissions를 그냥 가져오기
+    // submissions record 안에 들어가야 할 정보
+    // 번들 내에서 제출 회차, 제출 일자(연.월.일), 질문, 답변, 회고
+    return ApiResponse.success(surveyService.getSurveySubmissionHistory(command));
   }
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
@@ -192,7 +192,9 @@ class SurveyControllerTest extends ControllerTest {
 
     mockMvc
         .perform(
-            get("/api/v1/surveys/history/{bundleId}/submissions/{memberId}", 1L, 1L).with(csrf()))
+            get("/api/v1/surveys/members/{memberId}/submissions", 1L)
+                .queryParam("bundleId", "1")
+                .with(csrf()))
         .andExpect(status().isOk())
         .andDo(
             document(
@@ -202,12 +204,13 @@ class SurveyControllerTest extends ControllerTest {
                         .description("설문 결과를 조회")
                         .tag("Survey Domain")
                         .pathParameters(
-                            parameterWithName("bundleId")
-                                .type(SimpleType.NUMBER)
-                                .description("번들 ID"),
                             parameterWithName("memberId")
                                 .type(SimpleType.NUMBER)
                                 .description("회원 ID"))
+                        .queryParameters(
+                            parameterWithName("bundleId")
+                                .type(SimpleType.NUMBER)
+                                .description("번들 ID"))
                         .responseFields(
                             fieldWithPath("result").type(SimpleType.STRING).description("결과"),
                             fieldWithPath("data.surveyRecords").description("설문 이력"),


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 답변 목록 조회 API 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 답변 목록 조회 API를 구현하였습니다.

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
화면이 바뀌면서 기존에 사용하던 메서드 통해서 간단하게 구현할 수 있어져서 변경하였습니다.

그런데 화면 바뀌면서 고려해야 할 사항이 생기긴 했습니다. API 구현시 고려사항만 있는건 아니고, 서비스 내적으로도 필요 할 것 같습니다.
1. 현재 화면이 캐릭터 기준으로 조회하게 되어있는데, 캐릭터가 없으면 조회 자체를 못하는건지 즉 15회 모두 완료하지 않으면 못하는건지
2. 현재 API는 화면상 ~번째 캐릭터 를 선택시 내려주게 구현하였습니다. 따라서 ~번째 캐릭터에 대한 API 또한 존재해야 될 것으로 보입니다.
3. API를 index를 따로 안내려주고 List로 내려주고 있는데 index가 추가가 필요하면 추가하도록 하겠습니다.
