### PR TITLE
Feat(#71): n번째 캐릭터 목록 조회 api

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
@@ -27,7 +27,7 @@ public class CharacterService {
 
   private List<SurveyBundle> getSurveyBundles(final Long memberId) {
     return surveySubmissionRepository
-        .findSurveyBundlesByMemberIdAndDeletedAtIsNull(memberId)
+        .findWithSurveyBundlesByMemberIdAndDeletedAtIsNull(memberId)
         .stream()
         .map(it -> it.getSurvey().getSurveyBundle())
         .toList();

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
@@ -1,0 +1,35 @@
+package org.nexters.jaknaesocore.domain.character.service;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import org.nexters.jaknaesocore.domain.character.service.dto.CharacterResponse;
+import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
+import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveySubmissionRepository;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CharacterService {
+
+  private final MemberRepository memberRepository;
+  private final SurveySubmissionRepository surveySubmissionRepository;
+
+  public List<CharacterResponse> getCharacters(final Long memberId) {
+    memberRepository.findMember(memberId);
+
+    AtomicLong ordinalNumber = new AtomicLong(1);
+    return getSurveyBundles(memberId).stream()
+        .map(it -> new CharacterResponse(ordinalNumber.getAndIncrement(), it.getId()))
+        .toList();
+  }
+
+  private List<SurveyBundle> getSurveyBundles(final Long memberId) {
+    return surveySubmissionRepository
+        .findSurveyBundlesByMemberIdAndDeletedAtIsNull(memberId)
+        .stream()
+        .map(it -> it.getSurvey().getSurveyBundle())
+        .toList();
+  }
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/dto/CharacterResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/dto/CharacterResponse.java
@@ -1,0 +1,3 @@
+package org.nexters.jaknaesocore.domain.character.service.dto;
+
+public record CharacterResponse(Long ordinalNumber, Long bundleId) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
@@ -22,5 +22,5 @@ public interface SurveySubmissionRepository extends JpaRepository<SurveySubmissi
       "SELECT s FROM SurveySubmission s "
           + "JOIN FETCH s.member sm JOIN FETCH s.survey ss JOIN FETCH ss.surveyBundle sb "
           + "WHERE sm.id = :memberId AND s.deletedAt IS NULL")
-  List<SurveySubmission> findSurveyBundlesByMemberIdAndDeletedAtIsNull(final Long memberId);
+  List<SurveySubmission> findWithSurveyBundlesByMemberIdAndDeletedAtIsNull(final Long memberId);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.nexters.jaknaesocore.domain.survey.model.SurveySubmission;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface SurveySubmissionRepository extends JpaRepository<SurveySubmission, Long> {
 
@@ -16,4 +17,10 @@ public interface SurveySubmissionRepository extends JpaRepository<SurveySubmissi
 
   List<SurveySubmission> findByMember_IdAndSurvey_SurveyBundle_Id(
       final Long memberId, final Long bundleId);
+
+  @Query(
+      "SELECT s FROM SurveySubmission s "
+          + "JOIN FETCH s.member sm JOIN FETCH s.survey ss JOIN FETCH ss.surveyBundle sb "
+          + "WHERE sm.id = :memberId AND s.deletedAt IS NULL")
+  List<SurveySubmission> findSurveyBundlesByMemberIdAndDeletedAtIsNull(final Long memberId);
 }

--- a/jaknaeso-core/src/main/resources/sql/025/001_alter_table_survey_submission_add_submitted_at_col.sql
+++ b/jaknaeso-core/src/main/resources/sql/025/001_alter_table_survey_submission_add_submitted_at_col.sql
@@ -1,0 +1,2 @@
+alter table survey_submission
+  add submitted_at timestamp(6);

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.nexters.jaknaesocore.common.support.IntegrationTest;
 import org.nexters.jaknaesocore.common.support.error.CustomException;
-import org.nexters.jaknaesocore.domain.character.service.dto.CharacterQuestionsCommand;
 import org.nexters.jaknaesocore.domain.character.service.dto.CharacterResponse;
 import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
@@ -47,11 +46,6 @@ class CharacterServiceTest extends IntegrationTest {
     surveyRepository.deleteAllInBatch();
     surveyBundleRepository.deleteAllInBatch();
     memberRepository.deleteAllInBatch();
-  }
-
-  private CharacterQuestionsCommand createCharacterQuestionsCommand(
-      final Long memberId, final Long bundleId) {
-    return new CharacterQuestionsCommand(memberId, bundleId);
   }
 
   @Nested

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -68,45 +67,36 @@ class CharacterServiceTest extends IntegrationTest {
     @DisplayName("유저를 찾으면")
     class whenMemberFound {
 
-      private static final List<KeywordScore> scores =
-          List.of(
-              KeywordScore.builder().keyword(Keyword.SELF_DIRECTION).score(BigDecimal.ONE).build(),
-              KeywordScore.builder().keyword(Keyword.STABILITY).score(BigDecimal.TWO).build());
-
-      private SurveyBundle bundle;
-      private Survey survey;
-
-      private SurveyOption createSurveyOption(final Survey survey, final String content) {
-        return surveyOptionRepository.save(
-            SurveyOption.builder().survey(survey).content(content).scores(scores).build());
-      }
-
-      private SurveySubmission createSurveySubmission(
-          final Member member, final Survey survey, final SurveyOption option) {
-        return SurveySubmission.builder()
-            .member(member)
-            .survey(survey)
-            .selectedOption(option)
-            .build();
-      }
-
-      @BeforeEach
-      void setUp() {
-        bundle = surveyBundleRepository.save(new SurveyBundle());
-        survey =
-            surveyRepository.save(
-                new BalanceSurvey(
-                    "꿈에 그리던 드림 기업에 입사했다. 연봉도 좋지만, 무엇보다 회사의 근무 방식이 나와 잘 맞는 것 같다. 우리 회사의 근무 방식은...",
-                    bundle));
-      }
-
       @Test
       @DisplayName("회원의 캐릭터 리스트를 반환한다.")
       void shouldReturnQuestions() {
         final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
-        final SurveyOption option = createSurveyOption(survey, "자율 출퇴근제로 원하는 시간에 근무하며 창의적인 성과 내기");
-
-        surveySubmissionRepository.save(createSurveySubmission(member, survey, option));
+        final SurveyBundle bundle = surveyBundleRepository.save(new SurveyBundle());
+        final Survey survey =
+            surveyRepository.save(
+                new BalanceSurvey(
+                    "꿈에 그리던 드림 기업에 입사했다. 연봉도 좋지만, 무엇보다 회사의 근무 방식이 나와 잘 맞는 것 같다. 우리 회사의 근무 방식은...",
+                    bundle));
+        final List<KeywordScore> scores =
+            List.of(
+                KeywordScore.builder()
+                    .keyword(Keyword.SELF_DIRECTION)
+                    .score(BigDecimal.ONE)
+                    .build(),
+                KeywordScore.builder().keyword(Keyword.STABILITY).score(BigDecimal.TWO).build());
+        final SurveyOption option =
+            surveyOptionRepository.save(
+                SurveyOption.builder()
+                    .survey(survey)
+                    .content("자율 출퇴근제로 원하는 시간에 근무하며 창의적인 성과 내기")
+                    .scores(scores)
+                    .build());
+        surveySubmissionRepository.save(
+            SurveySubmission.builder()
+                .member(member)
+                .survey(survey)
+                .selectedOption(option)
+                .build());
 
         List<CharacterResponse> actual = sut.getCharacters(member.getId());
 

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
@@ -1,0 +1,128 @@
+package org.nexters.jaknaesocore.domain.character.service;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.nexters.jaknaesocore.common.support.IntegrationTest;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
+import org.nexters.jaknaesocore.domain.character.service.dto.CharacterQuestionsCommand;
+import org.nexters.jaknaesocore.domain.character.service.dto.CharacterResponse;
+import org.nexters.jaknaesocore.domain.member.model.Member;
+import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
+import org.nexters.jaknaesocore.domain.survey.model.BalanceSurvey;
+import org.nexters.jaknaesocore.domain.survey.model.Keyword;
+import org.nexters.jaknaesocore.domain.survey.model.KeywordScore;
+import org.nexters.jaknaesocore.domain.survey.model.Survey;
+import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
+import org.nexters.jaknaesocore.domain.survey.model.SurveyOption;
+import org.nexters.jaknaesocore.domain.survey.model.SurveySubmission;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveyBundleRepository;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveyOptionRepository;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveyRepository;
+import org.nexters.jaknaesocore.domain.survey.repository.SurveySubmissionRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class CharacterServiceTest extends IntegrationTest {
+
+  @Autowired private CharacterService sut;
+
+  @Autowired private MemberRepository memberRepository;
+  @Autowired private SurveyBundleRepository surveyBundleRepository;
+  @Autowired private SurveyRepository surveyRepository;
+  @Autowired private SurveyOptionRepository surveyOptionRepository;
+  @Autowired private SurveySubmissionRepository surveySubmissionRepository;
+
+  @AfterEach
+  void tearDown() {
+    surveySubmissionRepository.deleteAllInBatch();
+    surveyOptionRepository.deleteAllInBatch();
+    surveyRepository.deleteAllInBatch();
+    surveyBundleRepository.deleteAllInBatch();
+    memberRepository.deleteAllInBatch();
+  }
+
+  private CharacterQuestionsCommand createCharacterQuestionsCommand(
+      final Long memberId, final Long bundleId) {
+    return new CharacterQuestionsCommand(memberId, bundleId);
+  }
+
+  @Nested
+  @DisplayName("getCharacters 메소드는")
+  class getCharacters {
+
+    @Nested
+    @DisplayName("유저를 찾지 못하면")
+    class whenMemberNotFound {
+
+      @Test
+      @DisplayName("MEMBER_NOT_FOUND 예외를 던진다.")
+      void shouldThrowException() {
+        thenThrownBy(() -> sut.getCharacters(1L))
+            .hasMessage(CustomException.MEMBER_NOT_FOUND.getMessage());
+      }
+    }
+
+    @Nested
+    @DisplayName("유저를 찾으면")
+    class whenMemberFound {
+
+      private static final List<KeywordScore> scores =
+          List.of(
+              KeywordScore.builder().keyword(Keyword.SELF_DIRECTION).score(BigDecimal.ONE).build(),
+              KeywordScore.builder().keyword(Keyword.STABILITY).score(BigDecimal.TWO).build());
+
+      private SurveyBundle bundle;
+      private Survey survey;
+
+      private SurveyOption createSurveyOption(final Survey survey, final String content) {
+        return surveyOptionRepository.save(
+            SurveyOption.builder().survey(survey).content(content).scores(scores).build());
+      }
+
+      private SurveySubmission createSurveySubmission(
+          final Member member, final Survey survey, final SurveyOption option) {
+        return SurveySubmission.builder()
+            .member(member)
+            .survey(survey)
+            .selectedOption(option)
+            .build();
+      }
+
+      @BeforeEach
+      void setUp() {
+        bundle = surveyBundleRepository.save(new SurveyBundle());
+        survey =
+            surveyRepository.save(
+                new BalanceSurvey(
+                    "꿈에 그리던 드림 기업에 입사했다. 연봉도 좋지만, 무엇보다 회사의 근무 방식이 나와 잘 맞는 것 같다. 우리 회사의 근무 방식은...",
+                    bundle));
+      }
+
+      @Test
+      @DisplayName("회원의 캐릭터 리스트를 반환한다.")
+      void shouldReturnQuestions() {
+        final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
+        final SurveyOption option = createSurveyOption(survey, "자율 출퇴근제로 원하는 시간에 근무하며 창의적인 성과 내기");
+
+        surveySubmissionRepository.save(createSurveySubmission(member, survey, option));
+
+        List<CharacterResponse> actual = sut.getCharacters(member.getId());
+
+        assertAll(
+            () -> then(actual).hasSize(1),
+            () ->
+                then(actual.get(0))
+                    .extracting("ordinalNumber", "bundleId")
+                    .containsExactly(1L, bundle.getId()));
+      }
+    }
+  }
+}

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepositoryTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveySubmissionRepositoryTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.tuple;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
@@ -22,6 +21,7 @@ import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
 import org.nexters.jaknaesocore.domain.survey.model.SurveyOption;
 import org.nexters.jaknaesocore.domain.survey.model.SurveySubmission;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 class SurveySubmissionRepositoryTest extends IntegrationTest {
 
@@ -197,7 +197,8 @@ class SurveySubmissionRepositoryTest extends IntegrationTest {
         SurveySubmission.builder().member(member).survey(survey).selectedOption(option).build());
 
     List<SurveySubmission> actual =
-        surveySubmissionRepository.findSurveyBundlesByMemberIdAndDeletedAtIsNull(member.getId());
+        surveySubmissionRepository.findWithSurveyBundlesByMemberIdAndDeletedAtIsNull(
+            member.getId());
 
     assertAll(
         () -> then(actual).hasSize(1),

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterController.java
@@ -1,0 +1,25 @@
+package org.nexters.jaknaesoserver.domain.character.controller;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.nexters.jaknaesocore.common.support.response.ApiResponse;
+import org.nexters.jaknaesocore.domain.character.service.CharacterService;
+import org.nexters.jaknaesocore.domain.character.service.dto.CharacterResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/characters")
+@RestController
+public class CharacterController {
+
+  private final CharacterService characterService;
+
+  @GetMapping
+  public ApiResponse<List<CharacterResponse>> getCharacters(@RequestParam Long memberId) {
+    List<CharacterResponse> response = characterService.getCharacters(memberId);
+    return ApiResponse.success(response);
+  }
+}

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/common/support/ControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/common/support/ControllerTest.java
@@ -2,6 +2,7 @@ package org.nexters.jaknaesoserver.common.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.nexters.jaknaesocore.domain.auth.service.OauthService;
+import org.nexters.jaknaesocore.domain.character.service.CharacterService;
 import org.nexters.jaknaesocore.domain.member.service.MemberService;
 import org.nexters.jaknaesocore.domain.survey.service.SurveyService;
 import org.nexters.jaknaesoserver.config.TestSecurityConfig;
@@ -37,4 +38,6 @@ public abstract class ControllerTest {
   @MockitoBean protected JwtProvider jwtProvider;
 
   @MockitoBean protected SurveyService surveyService;
+
+  @MockitoBean protected CharacterService characterService;
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
@@ -6,6 +6,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithNam
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -30,6 +31,8 @@ class CharacterControllerTest extends ControllerTest {
     mockMvc
         .perform(
             get("/api/v1/characters")
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
                 .header("Refresh-Token", "Bearer refreshToken")
                 .queryParam("memberId", "1")
                 .with(csrf()))

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
@@ -1,0 +1,63 @@
+package org.nexters.jaknaesoserver.domain.character.controller;
+
+import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
+import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.Schema.schema;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.epages.restdocs.apispec.ResourceSnippetParameters;
+import com.epages.restdocs.apispec.SimpleType;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.nexters.jaknaesocore.domain.character.service.dto.CharacterResponse;
+import org.nexters.jaknaesoserver.common.support.ControllerTest;
+import org.nexters.jaknaesoserver.common.support.WithMockCustomUser;
+
+class CharacterControllerTest extends ControllerTest {
+
+  @WithMockCustomUser
+  @Test
+  void 캐릭터_목록을_조회한다() throws Exception {
+
+    given(characterService.getCharacters(1L)).willReturn(List.of(new CharacterResponse(1L, 1L)));
+
+    mockMvc
+        .perform(
+            get("/api/v1/characters")
+                .header("Refresh-Token", "Bearer refreshToken")
+                .queryParam("memberId", "1")
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "character-list-success",
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("캐릭터 목록 반환")
+                        .tag("Character Domain")
+                        .requestHeaders(headerWithName("Refresh-Token").description("리프레시 토큰"))
+                        .queryParameters(
+                            parameterWithName("memberId")
+                                .type(SimpleType.NUMBER)
+                                .description("멤버 아이디"))
+                        .responseFields(
+                            fieldWithPath("result")
+                                .type(SimpleType.STRING)
+                                .description("API 요청 결과 (성공/실패)"),
+                            fieldWithPath("data[].ordinalNumber")
+                                .type(SimpleType.NUMBER)
+                                .description("캐릭터 회차"),
+                            fieldWithPath("data[].bundleId")
+                                .type(SimpleType.NUMBER)
+                                .description("설문 번들 아이디"),
+                            fieldWithPath("error").description("에러").optional())
+                        .responseSchema(schema("List<CharacterResponse>"))
+                        .build())));
+  }
+}

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
@@ -1,7 +1,6 @@
 package org.nexters.jaknaesoserver.domain.character.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
@@ -33,7 +32,6 @@ class CharacterControllerTest extends ControllerTest {
             get("/api/v1/characters")
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
-                .header("Refresh-Token", "Bearer refreshToken")
                 .queryParam("memberId", "1")
                 .with(csrf()))
         .andExpect(status().isOk())
@@ -44,7 +42,6 @@ class CharacterControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("캐릭터 목록 반환")
                         .tag("Character Domain")
-                        .requestHeaders(headerWithName("Refresh-Token").description("리프레시 토큰"))
                         .queryParameters(
                             parameterWithName("memberId")
                                 .type(SimpleType.NUMBER)
@@ -60,7 +57,7 @@ class CharacterControllerTest extends ControllerTest {
                                 .type(SimpleType.NUMBER)
                                 .description("설문 번들 아이디"),
                             fieldWithPath("error").description("에러").optional())
-                        .responseSchema(schema("List<CharacterResponse>"))
+                        .responseSchema(schema("CharacterResponse"))
                         .build())));
   }
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
@@ -29,7 +29,7 @@ class MemberControllerTest extends ControllerTest {
 
     mockMvc
         .perform(
-            delete("/api/v1/members/1")
+            delete("/api/v1/members/{memberId}", 1)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))
@@ -52,7 +52,7 @@ class MemberControllerTest extends ControllerTest {
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/api/v1/members/1")
+            MockMvcRequestBuilders.get("/api/v1/members/{memberId}", 1L)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
캐릭터 목록 조회 api를 구현했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 캐릭터 목록 api를 위한 레포지토리, 서비스, 컨트롤러 작성

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
- core랑 server 모듈이 나뉘기 전에 controller, service 레포지토리 내에 dto 디렉토리를 두었는데 밖으로 빼면 될까요??
- rest api 어떤지 봐주시면 감사하겠습니다
- 혹시 `./gradlew runSwagger` 잘 되시나요? 저는 openapi3.yaml을 못 찾는다고 나와서 컨테이너 내리고 다시 실행하니까 되더라고요,,, 만약 다른 분들도 안되신다면 해당 스크립트 수정하겠습니다!