### PR TITLE
Feat(#59):pvq test api 온보딩 게임

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -28,6 +28,8 @@ public class CustomException extends RuntimeException {
   public static final CustomException FORBIDDEN_ACCESS = new CustomException(ErrorType.FORBIDDEN);
   public static final CustomException BUNDLE_NOT_FOUND =
       new CustomException(ErrorType.BUNDLE_NOT_FOUND);
+  public static final CustomException NOT_PROCEED_ONBOARDING =
+      new CustomException(ErrorType.NOT_PROCEED_ONBOARDING);
 
   private final ErrorType errorType;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
@@ -46,7 +46,9 @@ public enum ErrorType {
 
   ALREADY_COMPLETED_SURVEY_BUNDLE(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 완료된 설문 번들입니다.", LogLevel.WARN),
-  BUNDLE_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 번들을 찾을 수 없습니다.", LogLevel.WARN);
+  BUNDLE_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "해당 번들을 찾을 수 없습니다.", LogLevel.WARN),
+  NOT_PROCEED_ONBOARDING(
+      HttpStatus.FORBIDDEN, ErrorCode.E403, "온보딩을 진행해야 접근 가능합니다.", LogLevel.ERROR);
 
   private final HttpStatus status;
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSubmissionResult.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSubmissionResult.java
@@ -1,0 +1,3 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+public record OnboardingSubmissionResult(Long surveyId, Long optionId) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSubmissionsCommand.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSubmissionsCommand.java
@@ -1,0 +1,6 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+import java.util.List;
+
+public record OnboardingSubmissionsCommand(
+    List<OnboardingSubmissionResult> submissions, Long memberId) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSurveyResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/OnboardingSurveyResponse.java
@@ -1,0 +1,5 @@
+package org.nexters.jaknaesocore.domain.survey.dto;
+
+import java.util.List;
+
+public record OnboardingSurveyResponse(List<SurveyResponse> surveyResponses) {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/dto/SurveyHistoryResponse.java
@@ -19,8 +19,4 @@ public record SurveyHistoryResponse(
   public static SurveyHistoryResponse createNextBundleSurveyHistory(Long bundleId) {
     return new SurveyHistoryResponse(bundleId, List.of(), 1, false);
   }
-
-  public static SurveyHistoryResponse createInitialSurveyHistory() {
-    return new SurveyHistoryResponse(1L, List.of(), 1, false);
-  }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/OnboardingSurvey.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/OnboardingSurvey.java
@@ -1,0 +1,21 @@
+package org.nexters.jaknaesocore.domain.survey.model;
+
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DiscriminatorValue("ONBOARDING")
+public class OnboardingSurvey extends Survey {
+
+  public OnboardingSurvey(final String content, final SurveyBundle surveyBundle) {
+    super(content, surveyBundle);
+  }
+
+  @Override
+  public SurveyType getSurveyType() {
+    return SurveyType.ONBOARDING;
+  }
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/model/SurveyType.java
@@ -3,5 +3,6 @@ package org.nexters.jaknaesocore.domain.survey.model;
 public enum SurveyType {
   MULTIPLE_CHOICE,
   BALANCE,
+  ONBOARDING,
   ;
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/OnboardingSurveyRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/OnboardingSurveyRepository.java
@@ -1,0 +1,6 @@
+package org.nexters.jaknaesocore.domain.survey.repository;
+
+import org.nexters.jaknaesocore.domain.survey.model.OnboardingSurvey;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OnboardingSurveyRepository extends JpaRepository<OnboardingSurvey, Long> {}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepository.java
@@ -1,10 +1,11 @@
 package org.nexters.jaknaesocore.domain.survey.repository;
 
+import java.util.Collection;
 import java.util.Optional;
 import org.nexters.jaknaesocore.domain.survey.model.SurveyBundle;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SurveyBundleRepository extends JpaRepository<SurveyBundle, Long> {
 
-  Optional<SurveyBundle> findFirstByIdGreaterThanOrderByIdAsc(final Long id);
+  Optional<SurveyBundle> findFirstByIdNotInOrderByIdAsc(Collection<Long> ids);
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyRepository.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyRepository.java
@@ -1,6 +1,12 @@
 package org.nexters.jaknaesocore.domain.survey.repository;
 
+import java.util.List;
 import org.nexters.jaknaesocore.domain.survey.model.Survey;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-public interface SurveyRepository extends JpaRepository<Survey, Long> {}
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+
+  @Query("SELECT s FROM Survey s JOIN FETCH s.options WHERE s.id IN :surveyIds")
+  List<Survey> findAllByIdWithOptions(List<Long> surveyIds);
+}

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -13,6 +13,7 @@ import org.nexters.jaknaesocore.domain.member.model.Member;
 import org.nexters.jaknaesocore.domain.member.repository.MemberRepository;
 import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.model.*;
+import org.nexters.jaknaesocore.domain.survey.repository.OnboardingSurveyRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyBundleRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveyRepository;
 import org.nexters.jaknaesocore.domain.survey.repository.SurveySubmissionRepository;
@@ -27,6 +28,7 @@ public class SurveyService {
   private final SurveyBundleRepository surveyBundleRepository;
   private final SurveySubmissionRepository surveySubmissionRepository;
   private final SurveyRepository surveyRepository;
+  private final OnboardingSurveyRepository onboardingSurveyRepository;
 
   @Transactional(readOnly = true)
   public SurveyResponse getNextSurvey(final Long bundleId, final Long memberId) {
@@ -133,5 +135,13 @@ public class SurveyService {
         .collect(
             Collectors.collectingAndThen(
                 Collectors.toList(), SurveySubmissionHistoryResponse::new));
+  }
+
+  @Transactional(readOnly = true)
+  public OnboardingSurveyResponse getOnboardingSurveys() {
+    List<OnboardingSurvey> onboardingSurveys = onboardingSurveyRepository.findAll();
+    return onboardingSurveys.stream()
+        .map(SurveyResponse::of)
+        .collect(Collectors.collectingAndThen(Collectors.toList(), OnboardingSurveyResponse::new));
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepositoryTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/repository/SurveyBundleRepositoryTest.java
@@ -21,7 +21,7 @@ class SurveyBundleRepositoryTest extends IntegrationTest {
   }
 
   @Test
-  void 주어진_ID_보다_큰_번들_중_가장_작은_ID를_가진_번들을_찾는다() {
+  void 주어진_ID_목록에_없는_번들_중_가장_작은_ID를_가진_번들을_찾는다() {
     // given
     SurveyBundle surveyBundle1 = new SurveyBundle();
     SurveyBundle surveyBundle2 = new SurveyBundle();
@@ -30,9 +30,13 @@ class SurveyBundleRepositoryTest extends IntegrationTest {
 
     surveyBundleRepository.saveAll(
         List.of(surveyBundle1, surveyBundle2, surveyBundle3, surveyBundle4));
+
+    List<Long> excludedIds = List.of(surveyBundle1.getId(), surveyBundle2.getId());
+
     // when
     Optional<SurveyBundle> result =
-        surveyBundleRepository.findFirstByIdGreaterThanOrderByIdAsc(surveyBundle2.getId());
+        surveyBundleRepository.findFirstByIdNotInOrderByIdAsc(excludedIds);
+
     // then
     then(result)
         .hasValueSatisfying(
@@ -40,7 +44,7 @@ class SurveyBundleRepositoryTest extends IntegrationTest {
   }
 
   @Test
-  void 주어진_ID보다_큰_번들이_없으면_빈_값을_반환한다() {
+  void 모든_번들이_제외_목록에_있으면_빈_값을_반환한다() {
     // given
     SurveyBundle surveyBundle1 = new SurveyBundle();
     SurveyBundle surveyBundle2 = new SurveyBundle();
@@ -49,9 +53,18 @@ class SurveyBundleRepositoryTest extends IntegrationTest {
 
     surveyBundleRepository.saveAll(
         List.of(surveyBundle1, surveyBundle2, surveyBundle3, surveyBundle4));
+
+    List<Long> excludedIds =
+        List.of(
+            surveyBundle1.getId(),
+            surveyBundle2.getId(),
+            surveyBundle3.getId(),
+            surveyBundle4.getId());
+
     // when
     Optional<SurveyBundle> result =
-        surveyBundleRepository.findFirstByIdGreaterThanOrderByIdAsc(surveyBundle4.getId());
+        surveyBundleRepository.findFirstByIdNotInOrderByIdAsc(excludedIds);
+
     // then
     then(result).isEmpty();
   }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -139,7 +139,8 @@ class SurveyServiceTest extends IntegrationTest {
                 option.getId(), balanceSurvey.getId(), member.getId(), "나는 행복한게 좋으니까");
 
         // when
-        surveyService.submitSurvey(command, LocalDateTime.now());
+        LocalDateTime submittedAt = LocalDateTime.of(2025, 2, 13, 18, 0, 0);
+        surveyService.submitSurvey(command, submittedAt);
         // then
         List<SurveySubmission> submissions = surveySubmissionRepository.findAll();
         then(submissions).hasSize(1);
@@ -671,7 +672,7 @@ class SurveyServiceTest extends IntegrationTest {
         SurveyOption.builder().survey(survey4).scores(scores).content("나와 같다.").build();
 
     surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4));
-    LocalDateTime submittedAt = LocalDateTime.now();
+    LocalDateTime submittedAt = LocalDateTime.of(2025, 2, 13, 18, 25, 0);
 
     OnboardingSubmissionsCommand command =
         new OnboardingSubmissionsCommand(

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -571,4 +571,64 @@ class SurveyServiceTest extends IntegrationTest {
             tuple("나의 행복 지수는", "3점", null, "2025.01.03"),
             tuple("나는 노는게 좋다.", "4점", "당연히 노는게 좋은거 아닌가?", "2025.02.01"));
   }
+
+  @Test
+  void 온보딩_설문_목록을_가져온다() {
+    // given
+    Member member = Member.create("나민혁", "test@test.com");
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+
+    surveyBundleRepository.save(surveyBundle);
+
+    OnboardingSurvey survey1 =
+        new OnboardingSurvey(
+            "새로운 아이디어를 갖고 창의적인 것이 그/그녀에게 중요하다. 그/그녀는 일을 자신만의 독특한 방식으로 하는 것을 좋아한다.", surveyBundle);
+    OnboardingSurvey survey2 =
+        new OnboardingSurvey("그/그녀에게 부자가 되는 것은 중요하다. 많은 돈과 비싼 물건들을 가지길 원한다.", surveyBundle);
+    OnboardingSurvey survey3 =
+        new OnboardingSurvey(
+            "세상의 모든 사람들이 평등하게 대우받아야 한다고 생각한다. 그/그녀는 모든 사람이 인생에서 동등한 기회를 가져야 한다고 믿는다.",
+            surveyBundle);
+    OnboardingSurvey survey4 =
+        new OnboardingSurvey(
+            "그/그녀에게 자신의 능력을 보여주는 것이 매우 중요하다. 사람들이 자신이 하는 일을 인정해주길 바란다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+
+    List<KeywordScore> scores =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ADVENTURE).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores).content("전혀 나와 같지않다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey2).scores(scores).content("나와 같지 않다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey3).scores(scores).content("나와 조금 같다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey4).scores(scores).content("나와 같다.").build();
+
+    surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4));
+    // when
+    OnboardingSurveyResponse response = surveyService.getOnboardingSurveys();
+    // then
+    then(response.surveyResponses())
+        .extracting("id", "contents", "surveyType")
+        .containsExactly(
+            tuple(
+                survey1.getId(),
+                "새로운 아이디어를 갖고 창의적인 것이 그/그녀에게 중요하다. 그/그녀는 일을 자신만의 독특한 방식으로 하는 것을 좋아한다.",
+                "ONBOARDING"),
+            tuple(survey2.getId(), "그/그녀에게 부자가 되는 것은 중요하다. 많은 돈과 비싼 물건들을 가지길 원한다.", "ONBOARDING"),
+            tuple(
+                survey3.getId(),
+                "세상의 모든 사람들이 평등하게 대우받아야 한다고 생각한다. 그/그녀는 모든 사람이 인생에서 동등한 기회를 가져야 한다고 믿는다.",
+                "ONBOARDING"),
+            tuple(
+                survey4.getId(),
+                "그/그녀에게 자신의 능력을 보여주는 것이 매우 중요하다. 사람들이 자신이 하는 일을 인정해주길 바란다.",
+                "ONBOARDING"));
+  }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -182,7 +182,7 @@ class SurveyServiceTest extends IntegrationTest {
   }
 
   @Test
-  void 설문_기록이_없으면_1번_번들을_제공한다() {
+  void 설문_기록이_없으면_접근_할_수_없() {
     // given
     Member member = Member.create("나민혁", "test@test.com");
     memberRepository.save(member);
@@ -212,12 +212,10 @@ class SurveyServiceTest extends IntegrationTest {
         SurveyOption.builder().survey(survey4).scores(scores).content("4점").build();
     surveyOptionRepository.saveAll(List.of(option1, option2, option3, option4, option5, option6));
     // when
-    SurveyHistoryResponse response = surveyService.getSurveyHistory(member.getId());
-
     // then
-    then(response)
-        .extracting("bundleId", "nextSurveyIndex", "surveyHistoryDetails")
-        .containsExactly(1L, 1, List.of());
+    thenThrownBy(() -> surveyService.getSurveyHistory(member.getId()))
+        .isInstanceOf(CustomException.class)
+        .isEqualTo(CustomException.NOT_PROCEED_ONBOARDING);
   }
 
   @Test

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -183,7 +183,7 @@ class SurveyServiceTest extends IntegrationTest {
   }
 
   @Test
-  void 설문_기록이_없으면_접근_할_수_없() {
+  void 설문_기록이_없으면_접근_할_수_없다() {
     // given
     Member member = Member.create("나민혁", "test@test.com");
     memberRepository.save(member);

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -8,6 +8,7 @@ import org.nexters.jaknaesocore.common.support.response.ApiResponse;
 import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.service.SurveyService;
 import org.nexters.jaknaesoserver.domain.auth.model.CustomUserDetails;
+import org.nexters.jaknaesoserver.domain.survey.controller.dto.OnboardingSubmissionRequest;
 import org.nexters.jaknaesoserver.domain.survey.controller.dto.SurveySubmissionRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -66,5 +67,16 @@ public class SurveyController {
   @GetMapping("/onboarding")
   public ApiResponse<OnboardingSurveyResponse> getOnboardingSurvey() {
     return ApiResponse.success(surveyService.getOnboardingSurveys());
+  }
+
+  @ResponseStatus(HttpStatus.NO_CONTENT)
+  @PostMapping("/onboarding/submission")
+  public ApiResponse<?> submitOnboardingSurvey(
+      @AuthenticationPrincipal CustomUserDetails member,
+      @Valid @RequestBody OnboardingSubmissionRequest request) {
+    LocalDateTime submittedAt = LocalDateTime.now();
+
+    surveyService.submitOnboardingSurvey(request.toCommand(member.getMemberId()), submittedAt);
+    return ApiResponse.success();
   }
 }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyController.java
@@ -62,4 +62,9 @@ public class SurveyController {
         SurveySubmissionHistoryCommand.builder().bundleId(bundleId).memberId(memberId).build();
     return ApiResponse.success(surveyService.getSurveySubmissionHistory(command));
   }
+
+  @GetMapping("/onboarding")
+  public ApiResponse<OnboardingSurveyResponse> getOnboardingSurvey() {
+    return ApiResponse.success(surveyService.getOnboardingSurveys());
+  }
 }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/dto/OnboardingSubmissionInfoRequest.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/dto/OnboardingSubmissionInfoRequest.java
@@ -1,0 +1,3 @@
+package org.nexters.jaknaesoserver.domain.survey.controller.dto;
+
+public record OnboardingSubmissionInfoRequest(Long surveyId, Long optionId) {}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/dto/OnboardingSubmissionRequest.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/survey/controller/dto/OnboardingSubmissionRequest.java
@@ -1,0 +1,18 @@
+package org.nexters.jaknaesoserver.domain.survey.controller.dto;
+
+import java.util.List;
+import org.nexters.jaknaesocore.domain.survey.dto.OnboardingSubmissionResult;
+import org.nexters.jaknaesocore.domain.survey.dto.OnboardingSubmissionsCommand;
+
+public record OnboardingSubmissionRequest(List<OnboardingSubmissionInfoRequest> submissionsInfo) {
+  public OnboardingSubmissionsCommand toCommand(Long memberId) {
+    return new OnboardingSubmissionsCommand(
+        submissionsInfo.stream()
+            .map(
+                submissionInfo ->
+                    new OnboardingSubmissionResult(
+                        submissionInfo.surveyId(), submissionInfo.optionId()))
+            .toList(),
+        memberId);
+  }
+}

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
@@ -265,4 +265,89 @@ class SurveyControllerTest extends ControllerTest {
                 .with(csrf()))
         .andExpect(status().isForbidden());
   }
+
+  @WithMockCustomUser
+  @Test
+  void 온보딩_설문을_조회한다() throws Exception {
+    OnboardingSurveyResponse response =
+        new OnboardingSurveyResponse(
+            List.of(
+                new SurveyResponse(
+                    1L,
+                    "새로운 아이디어를 갖고 창의적인 것이 그/그녀에게 중요하다. 그/그녀는 일을 자신만의 독특한 방식으로 하는 것을 좋아한다.",
+                    "ONBOARDING",
+                    List.of(
+                        new SurveyOptionsResponse(1L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(2L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(3L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(4L, "나와 어느정도 같다."),
+                        new SurveyOptionsResponse(5L, "나와 같다."),
+                        new SurveyOptionsResponse(6L, "나와 매우 같다."))),
+                new SurveyResponse(
+                    2L,
+                    "그/그녀에게 부자가 되는 것은 중요하다. 많은 돈과 비싼 물건들을 가지길 원한다.",
+                    "ONBOARDING",
+                    List.of(
+                        new SurveyOptionsResponse(7L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(8L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(9L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(10L, "나와 어느정도 같다."),
+                        new SurveyOptionsResponse(11L, "나와 같다."),
+                        new SurveyOptionsResponse(12L, "나와 매우 같다."))),
+                new SurveyResponse(
+                    3L,
+                    "세상의 모든 사람들이 평등하게 대우받아야 한다고 생각한다. 그/그녀는 모든 사람이 인생에서 동등한 기회를 가져야 한다고 믿는다.",
+                    "ONBOARDING",
+                    List.of(
+                        new SurveyOptionsResponse(13L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(14L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(15L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(16L, "나와 어느정도 같다."),
+                        new SurveyOptionsResponse(17L, "나와 같다."),
+                        new SurveyOptionsResponse(18L, "나와 매우 같다."))),
+                new SurveyResponse(
+                    4L,
+                    "그/그녀에게 자신의 능력을 보여주는 것이 매우 중요하다. 사람들이 자신이 하는 일을 인정해주길 바란다.",
+                    "ONBOARDING",
+                    List.of(
+                        new SurveyOptionsResponse(19L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(20L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(21L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(22L, "나와 어느정도 같다."),
+                        new SurveyOptionsResponse(23L, "나와 같다."),
+                        new SurveyOptionsResponse(24L, "나와 매우 같다.")))));
+    given(surveyService.getOnboardingSurveys()).willReturn(response);
+
+    mockMvc
+        .perform(get("/api/v1/surveys/onboarding").with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "survey-get-onboarding",
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("온보딩 설문 조회")
+                        .tag("Survey Domain")
+                        .responseFields(
+                            fieldWithPath("result").type(SimpleType.STRING).description("결과"),
+                            fieldWithPath("data.surveyResponses").description("온보딩 설문"),
+                            fieldWithPath("data.surveyResponses[].id")
+                                .type(SimpleType.NUMBER)
+                                .description("설문 ID"),
+                            fieldWithPath("data.surveyResponses[].contents")
+                                .type(SimpleType.STRING)
+                                .description("설문 내용"),
+                            fieldWithPath("data.surveyResponses[].surveyType")
+                                .type(SimpleType.STRING)
+                                .description("설문 타입"),
+                            fieldWithPath("data.surveyResponses[].options[].id")
+                                .type(SimpleType.NUMBER)
+                                .description("설문지 옵션 ID"),
+                            fieldWithPath("data.surveyResponses[].options[].optionContents")
+                                .type(SimpleType.STRING)
+                                .description("설문지 옵션 내용"),
+                            fieldWithPath("error").description("에러").optional())
+                        .responseSchema(Schema.schema("onboardingSurveyResponse"))
+                        .build())));
+  }
 }

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
@@ -1,8 +1,7 @@
 package org.nexters.jaknaesoserver.domain.survey.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -282,46 +281,43 @@ class SurveyControllerTest extends ControllerTest {
                         new SurveyOptionsResponse(1L, "전혀 나와 같지 않다."),
                         new SurveyOptionsResponse(2L, "나와 같지 않다."),
                         new SurveyOptionsResponse(3L, "나와 조금 같다."),
-                        new SurveyOptionsResponse(4L, "나와 어느정도 같다."),
-                        new SurveyOptionsResponse(5L, "나와 같다."),
-                        new SurveyOptionsResponse(6L, "나와 매우 같다."))),
+                        new SurveyOptionsResponse(4L, "나와 같다."),
+                        new SurveyOptionsResponse(5L, "나와 매우 같다."))),
                 new SurveyResponse(
                     2L,
                     "그/그녀에게 부자가 되는 것은 중요하다. 많은 돈과 비싼 물건들을 가지길 원한다.",
                     "ONBOARDING",
                     List.of(
-                        new SurveyOptionsResponse(7L, "전혀 나와 같지 않다."),
-                        new SurveyOptionsResponse(8L, "나와 같지 않다."),
-                        new SurveyOptionsResponse(9L, "나와 조금 같다."),
-                        new SurveyOptionsResponse(10L, "나와 어느정도 같다."),
-                        new SurveyOptionsResponse(11L, "나와 같다."),
-                        new SurveyOptionsResponse(12L, "나와 매우 같다."))),
+                        new SurveyOptionsResponse(6L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(7L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(8L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(9L, "나와 같다."),
+                        new SurveyOptionsResponse(10L, "나와 매우 같다."))),
                 new SurveyResponse(
                     3L,
                     "세상의 모든 사람들이 평등하게 대우받아야 한다고 생각한다. 그/그녀는 모든 사람이 인생에서 동등한 기회를 가져야 한다고 믿는다.",
                     "ONBOARDING",
                     List.of(
-                        new SurveyOptionsResponse(13L, "전혀 나와 같지 않다."),
-                        new SurveyOptionsResponse(14L, "나와 같지 않다."),
-                        new SurveyOptionsResponse(15L, "나와 조금 같다."),
-                        new SurveyOptionsResponse(16L, "나와 어느정도 같다."),
-                        new SurveyOptionsResponse(17L, "나와 같다."),
-                        new SurveyOptionsResponse(18L, "나와 매우 같다."))),
+                        new SurveyOptionsResponse(11L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(12L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(13L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(14L, "나와 같다."),
+                        new SurveyOptionsResponse(15L, "나와 매우 같다."))),
                 new SurveyResponse(
                     4L,
                     "그/그녀에게 자신의 능력을 보여주는 것이 매우 중요하다. 사람들이 자신이 하는 일을 인정해주길 바란다.",
                     "ONBOARDING",
                     List.of(
-                        new SurveyOptionsResponse(19L, "전혀 나와 같지 않다."),
-                        new SurveyOptionsResponse(20L, "나와 같지 않다."),
-                        new SurveyOptionsResponse(21L, "나와 조금 같다."),
-                        new SurveyOptionsResponse(22L, "나와 어느정도 같다."),
-                        new SurveyOptionsResponse(23L, "나와 같다."),
-                        new SurveyOptionsResponse(24L, "나와 매우 같다.")))));
+                        new SurveyOptionsResponse(16L, "전혀 나와 같지 않다."),
+                        new SurveyOptionsResponse(17L, "나와 같지 않다."),
+                        new SurveyOptionsResponse(18L, "나와 조금 같다."),
+                        new SurveyOptionsResponse(19L, "나와 같다."),
+                        new SurveyOptionsResponse(20L, "나와 매우 같다.")))));
     given(surveyService.getOnboardingSurveys()).willReturn(response);
 
     mockMvc
-        .perform(get("/api/v1/surveys/onboarding").with(csrf()))
+        .perform(
+            get("/api/v1/surveys/onboarding").with(csrf()).header("Authorization", "Bearer token"))
         .andExpect(status().isOk())
         .andDo(
             document(
@@ -330,6 +326,10 @@ class SurveyControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("온보딩 설문 조회")
                         .tag("Survey Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .responseFields(
                             fieldWithPath("result").type(SimpleType.STRING).description("결과"),
                             fieldWithPath("data.surveyResponses").description("온보딩 설문"),
@@ -372,6 +372,7 @@ class SurveyControllerTest extends ControllerTest {
             post("/api/v1/surveys/onboarding/submission")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request))
+                .header("Authorization", "Bearer token")
                 .with(csrf()))
         .andExpect(status().isNoContent())
         .andDo(
@@ -381,6 +382,10 @@ class SurveyControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("온보딩 설문 제출")
                         .tag("Survey Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .requestFields(
                             fieldWithPath("submissionsInfo[].surveyId")
                                 .type(SimpleType.NUMBER)

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/survey/controller/SurveyControllerTest.java
@@ -24,6 +24,8 @@ import org.nexters.jaknaesocore.domain.survey.dto.*;
 import org.nexters.jaknaesocore.domain.survey.model.SurveyRecord;
 import org.nexters.jaknaesoserver.common.support.ControllerTest;
 import org.nexters.jaknaesoserver.common.support.WithMockCustomUser;
+import org.nexters.jaknaesoserver.domain.survey.controller.dto.OnboardingSubmissionInfoRequest;
+import org.nexters.jaknaesoserver.domain.survey.controller.dto.OnboardingSubmissionRequest;
 import org.nexters.jaknaesoserver.domain.survey.controller.dto.SurveySubmissionRequest;
 import org.springframework.http.MediaType;
 
@@ -348,6 +350,50 @@ class SurveyControllerTest extends ControllerTest {
                                 .description("설문지 옵션 내용"),
                             fieldWithPath("error").description("에러").optional())
                         .responseSchema(Schema.schema("onboardingSurveyResponse"))
+                        .build())));
+  }
+
+  @WithMockCustomUser
+  @Test
+  void 온보딩_설문에_응답을_제출한다() throws Exception {
+    willDoNothing()
+        .given(surveyService)
+        .submitOnboardingSurvey(any(OnboardingSubmissionsCommand.class), any(LocalDateTime.class));
+
+    OnboardingSubmissionRequest request =
+        new OnboardingSubmissionRequest(
+            List.of(
+                new OnboardingSubmissionInfoRequest(1L, 1L),
+                new OnboardingSubmissionInfoRequest(2L, 7L),
+                new OnboardingSubmissionInfoRequest(3L, 13L)));
+
+    mockMvc
+        .perform(
+            post("/api/v1/surveys/onboarding/submission")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+        .andExpect(status().isNoContent())
+        .andDo(
+            document(
+                "survey-submit-onboarding",
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("온보딩 설문 제출")
+                        .tag("Survey Domain")
+                        .requestFields(
+                            fieldWithPath("submissionsInfo[].surveyId")
+                                .type(SimpleType.NUMBER)
+                                .description("설문 ID"),
+                            fieldWithPath("submissionsInfo[].optionId")
+                                .type(SimpleType.NUMBER)
+                                .description("설문지 선택지 ID"))
+                        .responseFields(
+                            fieldWithPath("result").type(SimpleType.STRING).description("결과"),
+                            fieldWithPath("data").description("데이터").optional(),
+                            fieldWithPath("error").description("에러").optional())
+                        .requestSchema(Schema.schema("onboardingSubmissionRequest"))
+                        .responseSchema(Schema.schema("surveyResponse"))
                         .build())));
   }
 }


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 온보딩 게임 구현

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 온보딩 게임 조회 구현
- 온보딩 게임 제출 구현

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
아직 화면도 없기도 하고, 정책적으로도 뭔가 정해지지 않아서 일단 현재 다른 질문들과 동일하게 구현하였습니다.

우선 `ONBOARDING`으로 질문 타입 지정해서 따로 저장하도록 하였습니다. 따라서 온보딩에 대한 데이터를 따로 관리하도록 하였습니다. 이외에 설문에 대한 정보는 이중택일이나, PVQ 테스트나, 오지선다나 결국 선택지 중 하나를 택하는 것이라고 생각하여 `Survey`를 이용하고 각 질문에 따른 선택지에 대한 점수 등이 다르므로 현재 구조 그대로 이용하였습니다.

각 선택지마다 동일한 내용 (나와 같다, 나와 같지 않다) 등이 반복적으로 존재 할 것 으로 예상되지만 각 설문에 대하여 점수를 내기위해선 선택지에 대해서는 재활용이 어려울 것 같아서 지금 구조로 가야 할 것 같습니다. PVQ 테스트만이 아닌, 다중선택에 대해서도 이런형태로 가야되지않나 생각합니다.

온보딩 게임 제출에 대해서는 결과 데이터를 한번에 제출하도록 하였습니다.
그리고 일단은 모두 로그인 이후에 이루어지는 걸로 작성해두었는데 변경이 필요하면 변경하도록 하겠습니다.

---
이전에 번들값 가져오는 것 단순히 다음번들 가져오도록 했는데 제출하지않은 번들 중 가장 ID가 작은값 가져오도록 하였습니다.
기존에는 온보딩게임을 상정하고 만들지 않아서 처음 진입시에는 최초번들을 내려주도록 하였는데, 현재는 온보딩을 진행하지 않으면 질문 목록에 대한 접근권한이 없게 변경하였습니다.

## 논의해 봐야 할 사항
1. 온보딩이 로그인 이후 이루어지는지
1-1. 온보딩 게임에 대한 조회는 로그인 이전에 가능하게 할 것인지
2. 온보딩 게임은 필수적으로 진행해야 하는지
3. 온보딩 게임이 종료된 이후 최종 로직 처리 (캐릭터가 만들어진다 등)