### PR TITLE
Feat(#90): 최신 캐릭터 조회 api

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/character/service/CharacterService.java
@@ -26,15 +26,8 @@ public class CharacterService {
 
   @Transactional(readOnly = true)
   public CharacterResponse getCharacter(final CharacterCommand command) {
-    if (command.characterId() == null) {
-      return getCurrentCharacter(command.memberId());
-    }
-    return getSpecificCharacter(command.memberId(), command.characterId());
-  }
-
-  private CharacterResponse getCurrentCharacter(final Long memberId) {
     return characterRepository
-        .findTopByMemberIdAndDeletedAtIsNullWithMember(memberId)
+        .findByIdAndMemberIdAndDeletedAtIsNullWithMember(command.memberId(), command.characterId())
         .map(
             it ->
                 CharacterResponse.builder()
@@ -46,9 +39,10 @@ public class CharacterService {
         .orElseThrow(() -> CustomException.CHARACTER_NOT_FOUND);
   }
 
-  private CharacterResponse getSpecificCharacter(final Long memberId, final Long characterId) {
+  @Transactional(readOnly = true)
+  public CharacterResponse getCurrentCharacter(final Long memberId) {
     return characterRepository
-        .findByIdAndMemberIdAndDeletedAtIsNullWithMember(memberId, characterId)
+        .findTopByMemberIdAndDeletedAtIsNullWithMember(memberId)
         .map(
             it ->
                 CharacterResponse.builder()

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/character/service/CharacterServiceTest.java
@@ -96,64 +96,75 @@ class CharacterServiceTest extends IntegrationTest {
     }
 
     @Nested
-    @DisplayName("캐릭터 기록을 찾았고")
+    @DisplayName("캐릭터 기록을 찾으면")
     class whenCharacterFound {
 
-      @Nested
-      @DisplayName("characterId가 null이라면")
-      class whenBundleIdIsNull {
+      @Test
+      @DisplayName("회원의 특정 캐릭터 정보를 반환한다.")
+      void shouldReturnCharacter() {
+        final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
+        final SurveyBundle bundle = surveyBundleRepository.save(new SurveyBundle());
+        final Character character =
+            characterRepository.save(
+                Character.builder()
+                    .characterNo("첫번째")
+                    .characterType(CharacterType.SUCCESS)
+                    .startDate(LocalDate.now().minusDays(15))
+                    .endDate(LocalDate.now())
+                    .member(member)
+                    .surveyBundle(bundle)
+                    .build());
 
-        @Test
-        @DisplayName("회원의 현재 캐릭터 정보를 반환한다.")
-        void shouldReturnCurrentCharacter() {
-          final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
-          final SurveyBundle bundle = surveyBundleRepository.save(new SurveyBundle());
-          characterRepository.save(
-              Character.builder()
-                  .characterNo("첫번째")
-                  .characterType(CharacterType.SUCCESS)
-                  .startDate(LocalDate.now().minusDays(15))
-                  .endDate(LocalDate.now())
-                  .member(member)
-                  .surveyBundle(bundle)
-                  .build());
+        final CharacterResponse actual =
+            sut.getCharacter(createCharacterCommand(member.getId(), character.getId()));
 
-          final CharacterResponse actual =
-              sut.getCharacter(createCharacterCommand(member.getId(), null));
-
-          then(actual)
-              .extracting("characterNo", "characterType")
-              .containsExactly("첫번째", CharacterType.SUCCESS.getName());
-        }
+        then(actual)
+            .extracting("characterNo", "characterType")
+            .containsExactly("첫번째", CharacterType.SUCCESS.getName());
       }
+    }
+  }
 
-      @Nested
-      @DisplayName("characterId가 null이 아니라면")
-      class whenBundleIdIsNotNull {
+  @Nested
+  @DisplayName("getCurrentCharacter 메소드는")
+  class getCurrentCharacter {
 
-        @Test
-        @DisplayName("회원의 특정 캐릭터 정보를 반환한다.")
-        void shouldReturnSpecificCharacter() {
-          final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
-          final SurveyBundle bundle = surveyBundleRepository.save(new SurveyBundle());
-          final Character character =
-              characterRepository.save(
-                  Character.builder()
-                      .characterNo("첫번째")
-                      .characterType(CharacterType.SUCCESS)
-                      .startDate(LocalDate.now().minusDays(15))
-                      .endDate(LocalDate.now())
-                      .member(member)
-                      .surveyBundle(bundle)
-                      .build());
+    @Nested
+    @DisplayName("캐릭터 기록을 찾지 못하면")
+    class whenCharacterNotFound {
 
-          final CharacterResponse actual =
-              sut.getCharacter(createCharacterCommand(member.getId(), character.getId()));
+      @Test
+      @DisplayName("CHARACTER_NOT_FOUND 예외를 던진다.")
+      void shouldThrowException() {
+        thenThrownBy(() -> sut.getCharacter(createCharacterCommand(1L, 1L)))
+            .hasMessage(CustomException.CHARACTER_NOT_FOUND.getMessage());
+      }
+    }
 
-          then(actual)
-              .extracting("characterNo", "characterType")
-              .containsExactly("첫번째", CharacterType.SUCCESS.getName());
-        }
+    @Nested
+    @DisplayName("캐릭터 기록을 찾으면")
+    class whenCharacterFound {
+
+      @Test
+      @DisplayName("회원의 현재 캐릭터 정보를 반환한다.")
+      void shouldReturnCharacter() {
+        final Member member = memberRepository.save(Member.create("홍길동", "test@example.com"));
+        final SurveyBundle bundle = surveyBundleRepository.save(new SurveyBundle());
+        characterRepository.save(
+            Character.builder()
+                .characterNo("첫번째")
+                .characterType(CharacterType.SUCCESS)
+                .startDate(LocalDate.now().minusDays(15))
+                .endDate(LocalDate.now())
+                .member(member)
+                .surveyBundle(bundle)
+                .build());
+
+        final CharacterResponse actual = sut.getCurrentCharacter(member.getId());
+
+        then(actual)
+            .extracting("characterNo", "characterType")
+            .containsExactly("첫번째", CharacterType.SUCCESS.getName());
       }
     }
   }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterController.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterController.java
@@ -35,6 +35,12 @@ public class CharacterController {
     return ApiResponse.success(response);
   }
 
+  @GetMapping("/latest")
+  public ApiResponse<CharacterResponse> getCurrentCharacter(@RequestParam final Long memberId) {
+    CharacterResponse response = characterService.getCurrentCharacter(memberId);
+    return ApiResponse.success(response);
+  }
+
   @GetMapping("/{characterId}/report")
   public ApiResponse<CharacterValueReportResponse> getCharacterReport(
       @RequestParam final Long memberId, @PathVariable final Long characterId) {

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
@@ -147,6 +147,63 @@ class CharacterControllerTest extends ControllerTest {
 
   @WithMockCustomUser
   @Test
+  void 현재_캐릭터_정보를_조회한다() throws Exception {
+
+    given(characterService.getCurrentCharacter(1L))
+        .willReturn(
+            CharacterResponse.builder()
+                .characterNo("첫번째")
+                .type(CharacterType.SUCCESS.getName())
+                .description(CharacterType.SUCCESS.getDescription())
+                .startDate(LocalDate.now().minusDays(15))
+                .endDate(LocalDate.now())
+                .build());
+
+    mockMvc
+        .perform(
+            get("/api/v1/characters/latest")
+                .accept(APPLICATION_JSON)
+                .contentType(APPLICATION_JSON)
+                .queryParam("memberId", "1")
+                .with(csrf()))
+        .andExpect(status().isOk())
+        .andDo(
+            document(
+                "character-success",
+                resource(
+                    ResourceSnippetParameters.builder()
+                        .description("캐릭터 목록 반환")
+                        .tag("Character Domain")
+                        .queryParameters(
+                            parameterWithName("memberId")
+                                .type(SimpleType.NUMBER)
+                                .description("멤버 아이디"))
+                        .responseFields(
+                            fieldWithPath("result")
+                                .type(SimpleType.STRING)
+                                .description("API 요청 결과 (성공/실패)"),
+                            fieldWithPath("data.characterNo")
+                                .type(SimpleType.NUMBER)
+                                .description("캐릭터 회차"),
+                            fieldWithPath("data.characterType")
+                                .type(SimpleType.NUMBER)
+                                .description("캐릭터 타입"),
+                            fieldWithPath("data.description")
+                                .type(SimpleType.STRING)
+                                .description("캐릭터 설명"),
+                            fieldWithPath("data.startDate")
+                                .type(SimpleType.STRING)
+                                .description("시작 일자"),
+                            fieldWithPath("data.endDate")
+                                .type(SimpleType.STRING)
+                                .description("종료 일자"),
+                            fieldWithPath("error").description("에러").optional())
+                        .responseSchema(schema("CharacterResponse"))
+                        .build())));
+  }
+
+  @WithMockCustomUser
+  @Test
   void 특정_캐릭터의_가치관_분석_정보를_조회한다() throws Exception {
 
     given(characterService.getCharacterReport(any(CharacterValueReportCommand.class)))


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
홈화면에 필요한 최신 캐릭터 조회 api를 작성했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- api를 restful하게 변경하면서 최신 캐릭터를 조회할 수 있는 api가 사라졌습니다.
- 기존의 캐릭터 조회 api 서비스에서 null 확인 로직을 삭제하고, 최신 캐릭터 조회 로직을 새롭게 작성했습니다.
  - `/api/v1/characters/latest`