### PR TITLE
Refactor: 캐릭터 api 문서 보완

### DIFF
--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/character/controller/CharacterControllerTest.java
@@ -1,11 +1,13 @@
 package org.nexters.jaknaesoserver.domain.character.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -34,6 +36,8 @@ import org.nexters.jaknaesoserver.common.support.WithMockCustomUser;
 
 class CharacterControllerTest extends ControllerTest {
 
+  private static final String BEARER_TOKEN = "Bearer {accessToken}";
+
   @WithMockCustomUser
   @Test
   void 캐릭터_목록을_조회한다() throws Exception {
@@ -51,6 +55,7 @@ class CharacterControllerTest extends ControllerTest {
     mockMvc
         .perform(
             get("/api/v1/characters")
+                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .queryParam("memberId", "1")
@@ -58,11 +63,15 @@ class CharacterControllerTest extends ControllerTest {
         .andExpect(status().isOk())
         .andDo(
             document(
-                "character-list-success",
+                "get-character-list-success",
                 resource(
                     ResourceSnippetParameters.builder()
                         .description("캐릭터 목록 반환")
                         .tag("Character Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .queryParameters(
                             parameterWithName("memberId")
                                 .type(SimpleType.NUMBER)
@@ -100,6 +109,7 @@ class CharacterControllerTest extends ControllerTest {
     mockMvc
         .perform(
             get("/api/v1/characters/{characterId}", 1)
+                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .queryParam("memberId", "1")
@@ -107,11 +117,16 @@ class CharacterControllerTest extends ControllerTest {
         .andExpect(status().isOk())
         .andDo(
             document(
-                "specific-character-success",
+                "get-specific-character-success",
                 resource(
                     ResourceSnippetParameters.builder()
-                        .description("특정 캐릭터 반환")
+                        .summary("특정 캐릭터 반환")
+                        .description("캐릭터 아이디에 해당하는 캐릭터를 반환합니다.")
                         .tag("Character Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .pathParameters(
                             parameterWithName("characterId")
                                 .type(SimpleType.NUMBER)
@@ -167,6 +182,7 @@ class CharacterControllerTest extends ControllerTest {
     mockMvc
         .perform(
             get("/api/v1/characters/latest")
+                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .queryParam("memberId", "1")
@@ -174,11 +190,15 @@ class CharacterControllerTest extends ControllerTest {
         .andExpect(status().isOk())
         .andDo(
             document(
-                "latest-character-success",
+                "get-latest-character-success",
                 resource(
                     ResourceSnippetParameters.builder()
                         .description("최신(현재) 캐릭터 반환")
                         .tag("Character Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .queryParameters(
                             parameterWithName("memberId")
                                 .type(SimpleType.NUMBER)
@@ -233,6 +253,7 @@ class CharacterControllerTest extends ControllerTest {
     mockMvc
         .perform(
             get("/api/v1/characters/{characterId}/report", 1)
+                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .queryParam("memberId", "1")
@@ -240,11 +261,21 @@ class CharacterControllerTest extends ControllerTest {
         .andExpect(status().isOk())
         .andDo(
             document(
-                "character-value-report-success",
+                "get-character-value-report-success",
                 resource(
                     ResourceSnippetParameters.builder()
-                        .description("캐릭터 분석 정보 반환")
+                        .summary("캐릭터 가치관 분석 정보 반환")
+                        .description(
+                            """
+                            캐릭터의 가치관 분석 정보를 반환합니다.
+                            - 가치관 키워드와 각 키워드에 대한 퍼센트 리스트를 제공합니다.
+                            - 퍼센트 수치는 전체 가치관 대비 비율이 아닌, 개별 키워드마다 선택한 옵션 수를 기준으로 계산됩니다.
+                            """)
                         .tag("Character Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .pathParameters(
                             parameterWithName("characterId")
                                 .type(SimpleType.NUMBER)

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
@@ -1,12 +1,10 @@
 package org.nexters.jaknaesoserver.domain.member.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
-import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -34,7 +32,6 @@ class MemberControllerTest extends ControllerTest {
     mockMvc
         .perform(
             delete("/api/v1/members/{memberId}", 1)
-                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))
@@ -46,10 +43,6 @@ class MemberControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("회원 탈퇴")
                         .tags("Member Domain")
-                        .requestHeaders(
-                            headerWithName("Authorization")
-                                .type(SimpleType.STRING)
-                                .description("Bearer 토큰"))
                         .build())));
   }
 

--- a/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
+++ b/jaknaeso-server/src/test/java/org/nexters/jaknaesoserver/domain/member/controller/MemberControllerTest.java
@@ -1,14 +1,17 @@
 package org.nexters.jaknaesoserver.domain.member.controller;
 
 import static com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document;
+import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willDoNothing;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
@@ -17,9 +20,10 @@ import org.junit.jupiter.api.Test;
 import org.nexters.jaknaesocore.domain.member.service.dto.MemberResponse;
 import org.nexters.jaknaesoserver.common.support.ControllerTest;
 import org.nexters.jaknaesoserver.common.support.WithMockCustomUser;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 class MemberControllerTest extends ControllerTest {
+
+  private static final String BEARER_TOKEN = "Bearer {accessToken}";
 
   @WithMockCustomUser
   @Test
@@ -30,6 +34,7 @@ class MemberControllerTest extends ControllerTest {
     mockMvc
         .perform(
             delete("/api/v1/members/{memberId}", 1)
+                .header(AUTHORIZATION, BEARER_TOKEN)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))
@@ -41,6 +46,10 @@ class MemberControllerTest extends ControllerTest {
                     ResourceSnippetParameters.builder()
                         .description("회원 탈퇴")
                         .tags("Member Domain")
+                        .requestHeaders(
+                            headerWithName("Authorization")
+                                .type(SimpleType.STRING)
+                                .description("Bearer 토큰"))
                         .build())));
   }
 
@@ -52,7 +61,7 @@ class MemberControllerTest extends ControllerTest {
 
     mockMvc
         .perform(
-            MockMvcRequestBuilders.get("/api/v1/members/{memberId}", 1L)
+            get("/api/v1/members/{memberId}", 1L)
                 .accept(APPLICATION_JSON)
                 .contentType(APPLICATION_JSON)
                 .with(csrf()))


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
캐릭터 api 문서를 보완했습니다.

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- 인증한 사용자만 사용할 수 있는 api임을 명시했습니다.
- `캐릭터 가치관 분석` api의 경우, 퍼센트에 대한 정보가 부족하여 부연 설명을 덧붙였습니다.