### PR TITLE
Fix(#124): 온보딩 설문 제출 오류 수정

### DIFF
--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -256,6 +256,7 @@ public class SurveyService {
       List<OnboardingSubmissionResult> submissionResults, Map<Long, Survey> surveyMap) {
     Map<Survey, SurveyOption> surveyOptionMap =
         submissionResults.stream()
+            .distinct()
             .map(
                 submission -> {
                   Survey survey = surveyMap.get(submission.surveyId());
@@ -265,7 +266,11 @@ public class SurveyService {
                   SurveyOption option = survey.getOptionById(submission.optionId());
                   return Map.entry(survey, option);
                 })
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+            .collect(
+                Collectors.toMap(
+                    Map.Entry::getKey,
+                    Map.Entry::getValue,
+                    (existingOption, newOption) -> newOption));
     return surveyOptionMap;
   }
 }

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -663,6 +663,108 @@ class SurveyServiceTest extends IntegrationTest {
                 submittedAt.toLocalDate()));
   }
 
+  @Transactional
+  @Test
+  void 온보딩_설문을_제출할_때_동일한_설문에_대한_요청이_있으면_후순위_요청이_저장된다() {
+    // given
+    Member member = Member.create("나민혁", "test@test.com");
+    memberRepository.save(member);
+    SurveyBundle surveyBundle = new SurveyBundle();
+
+    final ValueCharacter valueCharacter =
+        valueCharacterRepository.save(
+            ValueCharacter.builder()
+                .name("아낌없이 주는 보금자리 유형")
+                .description("보금자리 유형 설명")
+                .keyword(Keyword.BENEVOLENCE)
+                .build());
+
+    surveyBundleRepository.save(surveyBundle);
+
+    OnboardingSurvey survey1 =
+        new OnboardingSurvey(
+            "새로운 아이디어를 갖고 창의적인 것이 그/그녀에게 중요하다. 그/그녀는 일을 자신만의 독특한 방식으로 하는 것을 좋아한다.", surveyBundle);
+    OnboardingSurvey survey2 =
+        new OnboardingSurvey("그/그녀에게 부자가 되는 것은 중요하다. 많은 돈과 비싼 물건들을 가지길 원한다.", surveyBundle);
+    OnboardingSurvey survey3 =
+        new OnboardingSurvey(
+            "세상의 모든 사람들이 평등하게 대우받아야 한다고 생각한다. 그/그녀는 모든 사람이 인생에서 동등한 기회를 가져야 한다고 믿는다.",
+            surveyBundle);
+    OnboardingSurvey survey4 =
+        new OnboardingSurvey(
+            "그/그녀에게 자신의 능력을 보여주는 것이 매우 중요하다. 사람들이 자신이 하는 일을 인정해주길 바란다.", surveyBundle);
+
+    surveyRepository.saveAll(List.of(survey1, survey2, survey3, survey4));
+
+    List<KeywordScore> scores1 =
+        List.of(
+            KeywordScore.builder().keyword(Keyword.ADVENTURE).score(BigDecimal.ONE).build(),
+            KeywordScore.builder().keyword(Keyword.BENEVOLENCE).score(BigDecimal.TWO).build());
+    List<KeywordScore> scores2 =
+        List.of(
+            KeywordScore.builder()
+                .keyword(Keyword.ADVENTURE)
+                .score(BigDecimal.valueOf(-1))
+                .build());
+
+    SurveyOption option0 =
+        SurveyOption.builder().survey(survey1).scores(scores1).content("전혀 나와 같지않다.").build();
+    SurveyOption option1 =
+        SurveyOption.builder().survey(survey1).scores(scores1).content("전혀 나와 같지않다.").build();
+    SurveyOption option2 =
+        SurveyOption.builder().survey(survey2).scores(scores1).content("나와 같지 않다.").build();
+    SurveyOption option3 =
+        SurveyOption.builder().survey(survey3).scores(scores2).content("나와 조금 같다.").build();
+    SurveyOption option4 =
+        SurveyOption.builder().survey(survey4).scores(scores2).content("나와 같다.").build();
+
+    surveyOptionRepository.saveAll(List.of(option0, option1, option2, option3, option4));
+    LocalDateTime submittedAt = LocalDateTime.of(2025, 2, 13, 18, 25, 0);
+
+    OnboardingSubmissionsCommand command =
+        new OnboardingSubmissionsCommand(
+            List.of(
+                new OnboardingSubmissionResult(survey1.getId(), option0.getId()),
+                new OnboardingSubmissionResult(survey1.getId(), option1.getId()),
+                new OnboardingSubmissionResult(survey2.getId(), option2.getId()),
+                new OnboardingSubmissionResult(survey3.getId(), option3.getId()),
+                new OnboardingSubmissionResult(survey4.getId(), option4.getId())),
+            member.getId());
+    // when
+    surveyService.submitOnboardingSurvey(command, submittedAt);
+    // then
+    List<SurveySubmission> submissions = surveySubmissionRepository.findAll();
+
+    then(submissions).hasSize(4);
+    then(submissions)
+        .extracting("member.id", "survey.id", "selectedOption.id", "submittedAt")
+        .containsExactlyInAnyOrder(
+            tuple(member.getId(), survey1.getId(), option1.getId(), submittedAt),
+            tuple(member.getId(), survey2.getId(), option2.getId(), submittedAt),
+            tuple(member.getId(), survey3.getId(), option3.getId(), submittedAt),
+            tuple(member.getId(), survey4.getId(), option4.getId(), submittedAt));
+    then(member).extracting("completedOnboardingAt").isEqualTo(submittedAt);
+    then(characterRecordRepository.findAll())
+        .hasSize(1)
+        .extracting(
+            "ordinalNumber",
+            "characterNo",
+            "member.id",
+            "surveyBundle.id",
+            "valueCharacter.id",
+            "startDate",
+            "endDate")
+        .containsExactly(
+            tuple(
+                1,
+                "첫번째 캐릭터",
+                member.getId(),
+                surveyBundle.getId(),
+                valueCharacter.getId(),
+                submittedAt.toLocalDate(),
+                submittedAt.toLocalDate()));
+  }
+
   @Test
   void 온보딩을_이미_완료했으면_진행할_수_없다() {
     // given


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
- 온보딩 설문 제출 오류 수정

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- RequestBody에 동일한 Survey에 대한 요청이 존재 할 시 발생하는 에러
- 해당 에러 해결을 위해 중복을 허용하되, 뒤에 들어오는 요청으로 덮어씌우도록 수정

예외 발생 상황 파악 후 해당 테스트 통해서 정상적으로 처리되는 것을 확인하였습니다.