### PR TITLE
Feat(#130): elk 로깅 추가

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -56,8 +56,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME }}:${{ env.BUILD_NUMBER }}
             ${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME }}:latest
-          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache,image-manifest=true,oci-mediatypes=true
-          cache-to: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache,mode=max,image-manifest=true,oci-mediatypes=true
+          cache-from: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY_URL }}/${{ env.SERVICE_NAME}}:buildcache,mode=max
 
       - name: Setting NCP CLI & Credentials
         run: |
@@ -96,7 +96,7 @@ jobs:
           username: ${{ env.NCP_SERVER_USERNAME }}
           password: ${{ env.NCP_SERVER_PASSWORD }}
           port: ${{ env.SSH_PORT }}
-          source: "docker-compose.yml,.env,nginx/default.conf,scripts/server/*"
+          source: "docker-compose.yml,.env,nginx/default.conf,scripts/server/*,logstash.conf,docker-compose.elk.yml"
           target: "~/"
           overwrite: true
 
@@ -111,7 +111,7 @@ jobs:
             docker login ${{ env.REGISTRY_URL }} -u ${{ env.NCP_ACCESS_KEY }} -p ${{ env.NCP_SECRET_KEY }}
 
             docker-compose -f ~/docker-compose.yml pull
-            docker-compose -f ~/docker-compose.yml up -d --remove-orphans
+            docker-compose -f ~/docker-compose.elk.yml up -d -f ~/docker-compose.yml up -d
             docker-compose exec nginx nginx -s reload
             
             chmod +x ~/scripts/server/register-certbot-cron-job.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,15 +43,6 @@ subprojects {
         dependsOn("spotlessApply")
     }
 
-    configurations {
-        compileOnly {
-            extendsFrom(configurations.annotationProcessor.get())
-        }
-        all {
-            exclude(group = "org.springframework.boot", module = "spring-boot-starter-logging")
-        }
-    }
-
     dependencies {
         implementation("org.springframework.boot:spring-boot-starter-web")
         compileOnly("org.projectlombok:lombok")
@@ -59,23 +50,21 @@ subprojects {
         testCompileOnly("org.projectlombok:lombok")
         testAnnotationProcessor("org.projectlombok:lombok")
 
+        implementation("org.springframework.boot:spring-boot-starter-logging")
+        implementation("org.slf4j:slf4j-api")
         testImplementation("org.springframework.boot:spring-boot-starter-test")
 
         testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-
-        // log4j2
-        implementation("org.springframework.boot:spring-boot-starter-log4j2")
-        implementation("com.lmax:disruptor:4.0.0")
 
         // p6spy (local db query log)
         implementation("p6spy:p6spy:3.9.1")
         implementation("com.github.vertical-blank:sql-formatter:2.0.5")
 
-        // log4jdbc
-        implementation("org.bgee.log4jdbc-log4j2:log4jdbc-log4j2-jdbc4.1:1.16")
-
         // Jackson
         implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.18.2")
+
+        // Logstash
+        implementation("net.logstash.logback:logstash-logback-encoder:7.4")
     }
 }
 

--- a/docker-compose.elk.yml
+++ b/docker-compose.elk.yml
@@ -1,0 +1,52 @@
+version: '3.8'
+
+services:
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    container_name: elasticsearch
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - xpack.security.http.ssl.enabled=false
+      - TZ=Asia/Seoul
+    ports:
+      - "9200:9200"
+    networks:
+      - elastic-network
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.10.0
+    container_name: logstash
+    environment:
+      - TZ=Asia/Seoul
+    ports:
+      - "5044:5044"
+      - "9600:9600"
+    volumes:
+      - ./logstash.conf:/usr/share/logstash/pipeline/logstash.conf
+    depends_on:
+      - elasticsearch
+    networks:
+      - elastic-network
+
+  kibana:
+    image: kibana:8.10.1
+    container_name: kibana
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - TZ=Asia/Seoul
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+    networks:
+      - elastic-network
+
+networks:
+  elastic-network:
+    driver: bridge
+
+volumes:
+  elasticsearch-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - mysql
     networks:
       - jaknaeso-network
+      - elastic-network
     restart: on-failure
 
   nginx:
@@ -73,4 +74,6 @@ services:
 
 networks:
   jaknaeso-network:
+    driver: bridge
+  elastic-network:
     driver: bridge

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -24,8 +24,8 @@ public class CustomException extends RuntimeException {
       new CustomException(ErrorType.SURVEY_OPTION_NOT_FOUND);
   public static final CustomException SURVEY_NOT_FOUND =
       new CustomException(ErrorType.SURVEY_NOT_FOUND);
-  public static final CustomException NOT_READY_FOR_NEXT_BUNDLE =
-      new CustomException(ErrorType.NOT_READY_FOR_NEXT_BUNDLE);
+  public static final CustomException COMPLETED_EXIST_SURVEY_BUNDLE =
+      new CustomException(ErrorType.COMPLETED_EXIST_SURVEY_BUNDLE);
   public static final CustomException ALREADY_COMPLETED_SURVEY_BUNDLE =
       new CustomException(ErrorType.ALREADY_COMPLETED_SURVEY_BUNDLE);
   public static final CustomException BUNDLE_NOT_FOUND =

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/CustomException.java
@@ -24,8 +24,8 @@ public class CustomException extends RuntimeException {
       new CustomException(ErrorType.SURVEY_OPTION_NOT_FOUND);
   public static final CustomException SURVEY_NOT_FOUND =
       new CustomException(ErrorType.SURVEY_NOT_FOUND);
-  public static final CustomException COMPLETED_EXIST_SURVEY_BUNDLE =
-      new CustomException(ErrorType.COMPLETED_EXIST_SURVEY_BUNDLE);
+  public static final CustomException NO_MORE_SURVEY_BUNDLES =
+      new CustomException(ErrorType.NO_MORE_SURVEY_BUNDLES);
   public static final CustomException ALREADY_COMPLETED_SURVEY_BUNDLE =
       new CustomException(ErrorType.ALREADY_COMPLETED_SURVEY_BUNDLE);
   public static final CustomException BUNDLE_NOT_FOUND =

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorMessage.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorMessage.java
@@ -11,15 +11,26 @@ public class ErrorMessage {
 
   private final Object data;
 
+  private final String traceId;
+
   public ErrorMessage(ErrorType errorType) {
     this.code = errorType.getCode().name();
     this.message = errorType.getMessage();
     this.data = null;
+    this.traceId = null;
   }
 
   public ErrorMessage(ErrorType errorType, Object data) {
     this.code = errorType.getCode().name();
     this.message = errorType.getMessage();
     this.data = data;
+    this.traceId = null;
+  }
+
+  public ErrorMessage(ErrorType errorType, Object data, String traceId) {
+    this.code = errorType.getCode().name();
+    this.message = errorType.getMessage();
+    this.data = data;
+    this.traceId = traceId;
   }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
@@ -41,8 +41,11 @@ public enum ErrorType {
   SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 설문입니다.", LogLevel.WARN),
 
   // survey
-  COMPLETED_EXIST_SURVEY_BUNDLE(
-      HttpStatus.BAD_REQUEST, ErrorCode.E400, "다음 번들을 진행할 준비가 되지 않았습니다.", LogLevel.ERROR),
+  NO_MORE_SURVEY_BUNDLES(
+      HttpStatus.BAD_REQUEST,
+      ErrorCode.E400,
+      "다음 번들을 진행할 준비가 되지 않았습니다. 추가로 진행할 번들이 필요합니다.",
+      LogLevel.ERROR),
 
   ALREADY_COMPLETED_SURVEY_BUNDLE(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 완료된 설문 번들입니다.", LogLevel.WARN),

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/error/ErrorType.java
@@ -10,12 +10,12 @@ public enum ErrorType {
   DEFAULT_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR, ErrorCode.E500, "예기치 않은 오류가 발생했습니다.", LogLevel.ERROR),
   METHOD_ARGUMENT_NOT_VALID(
-      HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력하신 데이터가 올바르지 않습니다.", LogLevel.DEBUG),
+      HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력하신 데이터가 올바르지 않습니다.", LogLevel.INFO),
   BINDING_ERROR(HttpStatus.BAD_REQUEST, ErrorCode.E400, "입력 형식이 올바르지 않습니다.", LogLevel.WARN),
   RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "요청하신 리소스를 찾을 수 없습니다.", LogLevel.WARN),
 
   // token
-  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E4011, "토큰이 만료되었습니다.", LogLevel.WARN),
+  EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E4011, "토큰이 만료되었습니다.", LogLevel.INFO),
   INVALID_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E401, "유효하지 않은 토큰입니다.", LogLevel.WARN),
   UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, ErrorCode.E401, "지원하지 않는 형식의 토큰입니다.", LogLevel.WARN),
   INCORRECT_TOKEN_FORMAT(
@@ -41,8 +41,8 @@ public enum ErrorType {
   SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, ErrorCode.E404, "존재하지 않는 설문입니다.", LogLevel.WARN),
 
   // survey
-  NOT_READY_FOR_NEXT_BUNDLE(
-      HttpStatus.BAD_REQUEST, ErrorCode.E400, "다음 번들을 진행할 준비가 되지 않았습니다.", LogLevel.WARN),
+  COMPLETED_EXIST_SURVEY_BUNDLE(
+      HttpStatus.BAD_REQUEST, ErrorCode.E400, "다음 번들을 진행할 준비가 되지 않았습니다.", LogLevel.ERROR),
 
   ALREADY_COMPLETED_SURVEY_BUNDLE(
       HttpStatus.BAD_REQUEST, ErrorCode.E400, "이미 완료된 설문 번들입니다.", LogLevel.WARN),

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/response/ApiResponse.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/common/support/response/ApiResponse.java
@@ -33,4 +33,8 @@ public class ApiResponse<S> {
   public static ApiResponse<?> error(ErrorType error, Object errorData) {
     return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error, errorData));
   }
+
+  public static ApiResponse<?> error(ErrorType error, Object errorData, String traceId) {
+    return new ApiResponse<>(ResultType.ERROR, null, new ErrorMessage(error, errorData, traceId));
+  }
 }

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -128,7 +128,7 @@ public class SurveyService {
     SurveyBundle nextBundle =
         surveyBundleRepository
             .findFirstByIdNotInOrderByIdAsc(bundleIds)
-            .orElseThrow(() -> CustomException.COMPLETED_EXIST_SURVEY_BUNDLE);
+            .orElseThrow(() -> CustomException.NO_MORE_SURVEY_BUNDLES);
     return SurveyHistoryResponse.createNextBundleSurveyHistory(nextBundle.getId());
   }
 

--- a/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
+++ b/jaknaeso-core/src/main/java/org/nexters/jaknaesocore/domain/survey/service/SurveyService.java
@@ -128,7 +128,7 @@ public class SurveyService {
     SurveyBundle nextBundle =
         surveyBundleRepository
             .findFirstByIdNotInOrderByIdAsc(bundleIds)
-            .orElseThrow(() -> CustomException.NOT_READY_FOR_NEXT_BUNDLE);
+            .orElseThrow(() -> CustomException.COMPLETED_EXIST_SURVEY_BUNDLE);
     return SurveyHistoryResponse.createNextBundleSurveyHistory(nextBundle.getId());
   }
 

--- a/jaknaeso-core/src/main/resources/log/logback-dev.xml
+++ b/jaknaeso-core/src/main/resources/log/logback-dev.xml
@@ -1,5 +1,6 @@
 <configuration>
     <property name="LOG_FILE" value="application.log"/>
+    <property name="LOG_PATH" value="/var/log/jaknaeso"/>
 
     <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>logstash:5044</destination>
@@ -11,8 +12,9 @@
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${LOG_FILE}</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>application.%d{yyyy-MM-dd_HH-mm}.log.gz</fileNamePattern>
-            <maxHistory>5</maxHistory>
+            <fileNamePattern>app-%d{yyyy-MM-dd}-%i.log.gz</fileNamePattern>
+            <maxHistory>7</maxHistory>
+            <maxFileSize>10MB</maxFileSize>
         </rollingPolicy>
         <encoder>
             <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n%throwable</pattern>

--- a/jaknaeso-core/src/main/resources/log/logback-dev.xml
+++ b/jaknaeso-core/src/main/resources/log/logback-dev.xml
@@ -1,0 +1,26 @@
+<configuration>
+    <property name="LOG_FILE" value="application.log"/>
+
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>logstash:5044</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeCallerData>true</includeCallerData>
+        </encoder>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_FILE}</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>application.%d{yyyy-MM-dd_HH-mm}.log.gz</fileNamePattern>
+            <maxHistory>5</maxHistory>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n%throwable</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="FILE" />
+        <appender-ref ref="LOGSTASH" />
+    </root>
+</configuration>

--- a/jaknaeso-core/src/main/resources/log/logback-local.xml
+++ b/jaknaeso-core/src/main/resources/log/logback-local.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <property name="LOG_FILE" value="application.log"/>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level [%thread] %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="info">
+        <appender-ref ref="CONSOLE" />
+    </root>
+</configuration>

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -423,7 +423,7 @@ class SurveyServiceTest extends IntegrationTest {
     // then
     thenThrownBy(() -> surveyService.getSurveyHistory(member.getId()))
         .isInstanceOf(CustomException.class)
-        .isEqualTo(CustomException.NOT_READY_FOR_NEXT_BUNDLE);
+        .isEqualTo(CustomException.COMPLETED_EXIST_SURVEY_BUNDLE);
   }
 
   @Test

--- a/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
+++ b/jaknaeso-core/src/test/java/org/nexters/jaknaesocore/domain/survey/service/SurveyServiceTest.java
@@ -423,7 +423,7 @@ class SurveyServiceTest extends IntegrationTest {
     // then
     thenThrownBy(() -> surveyService.getSurveyHistory(member.getId()))
         .isInstanceOf(CustomException.class)
-        .isEqualTo(CustomException.COMPLETED_EXIST_SURVEY_BUNDLE);
+        .isEqualTo(CustomException.NO_MORE_SURVEY_BUNDLES);
   }
 
   @Test

--- a/jaknaeso-server/build.gradle.kts
+++ b/jaknaeso-server/build.gradle.kts
@@ -16,12 +16,6 @@ dependencies {
     testImplementation(platform("org.junit:junit-bom:5.10.0"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 
-    // h2
-    testRuntimeOnly("com.h2database:h2")
-
-    // spring-data-jpa
-    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa")
-
     // restdocs-api-spec
     testImplementation("com.epages:restdocs-api-spec-mockmvc:0.19.4")
 
@@ -39,6 +33,8 @@ dependencies {
     
     // validation
     implementation("org.springframework.boot:spring-boot-starter-validation")
+
+    implementation("org.springframework.boot:spring-boot-starter-aop")
 }
 
 tasks.withType<Test> {

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/common/controller/ApiControllerAdvice.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/common/controller/ApiControllerAdvice.java
@@ -1,5 +1,6 @@
 package org.nexters.jaknaesoserver.common.controller;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 import java.util.Map;
@@ -23,14 +24,16 @@ import org.springframework.web.servlet.resource.NoResourceFoundException;
 public class ApiControllerAdvice {
 
   @ExceptionHandler(CustomException.class)
-  public ResponseEntity<ApiResponse<?>> handleCustomException(CustomException e) {
+  public ResponseEntity<ApiResponse<?>> handleCustomException(
+      CustomException e, HttpServletRequest request) {
     switch (e.getErrorType().getLogLevel()) {
       case ERROR -> log.error("CustomException : {}", e.getMessage(), e);
       case WARN -> log.warn("CustomException : {}", e.getMessage(), e);
       default -> log.info("CustomException : {}", e.getMessage(), e);
     }
+    String traceId = (String) request.getAttribute("traceId");
     return new ResponseEntity<>(
-        ApiResponse.error(e.getErrorType(), e.getData()), e.getErrorType().getStatus());
+        ApiResponse.error(e.getErrorType(), e.getData(), traceId), e.getErrorType().getStatus());
   }
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
@@ -128,9 +131,10 @@ public class ApiControllerAdvice {
   }
 
   @ExceptionHandler(Exception.class)
-  public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
+  public ResponseEntity<ApiResponse<?>> handleException(Exception e, HttpServletRequest request) {
     log.error("Exception : {}", e.getMessage(), e);
     return new ResponseEntity<>(
-        ApiResponse.error(ErrorType.DEFAULT_ERROR), ErrorType.DEFAULT_ERROR.getStatus());
+        ApiResponse.error(ErrorType.DEFAULT_ERROR, null, (String) request.getAttribute("traceId")),
+        ErrorType.DEFAULT_ERROR.getStatus());
   }
 }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/config/SecurityConfig.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.nexters.jaknaesoserver.common.controller.PublicEndpoints;
 import org.nexters.jaknaesoserver.domain.auth.filter.JwtAuthFilter;
 import org.nexters.jaknaesoserver.domain.auth.handler.SecurityExceptionHandler;
+import org.nexters.jaknaesoserver.logging.RequestResponseFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 public class SecurityConfig {
 
   private final SecurityExceptionHandler securityExceptionHandler;
+  private final RequestResponseFilter requestResponseFilter;
   private final JwtAuthFilter jwtAuthFilter;
   private final CorsConfigurationSource corsConfigurationSource;
 
@@ -45,6 +47,7 @@ public class SecurityConfig {
                 exception
                     .authenticationEntryPoint(securityExceptionHandler)
                     .accessDeniedHandler(securityExceptionHandler))
+        .addFilterBefore(requestResponseFilter, UsernamePasswordAuthenticationFilter.class)
         .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
         .build();
   }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/auth/controller/dto/KakaoLoginRequest.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/auth/controller/dto/KakaoLoginRequest.java
@@ -1,6 +1,6 @@
 package org.nexters.jaknaesoserver.domain.auth.controller.dto;
 
-import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import org.nexters.jaknaesocore.domain.auth.service.dto.KakaoLoginCommand;
 
 public record KakaoLoginRequest(@NotBlank String code, @NotBlank String redirectUri) {

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/auth/controller/dto/KakaoLoginWithTokenRequest.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/domain/auth/controller/dto/KakaoLoginWithTokenRequest.java
@@ -1,6 +1,6 @@
 package org.nexters.jaknaesoserver.domain.auth.controller.dto;
 
-import org.apache.logging.log4j.core.config.plugins.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotBlank;
 import org.nexters.jaknaesocore.domain.auth.service.dto.KakaoLoginWithTokenCommand;
 
 public record KakaoLoginWithTokenRequest(@NotBlank String accessToken) {

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
@@ -1,0 +1,77 @@
+package org.nexters.jaknaesoserver.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Component
+@Aspect
+public class ApiRequestResponseAop {
+  private final ObjectMapper objectMapper;
+
+  public ApiRequestResponseAop(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Pointcut("within(org.nexters.jaknaesoserver.domain..controller..*)")
+  public void apiRestPointCut() {}
+
+  @Around("apiRestPointCut()")
+  public Object reqeustResponseLogging(ProceedingJoinPoint joinPoint) throws Throwable {
+    ServletRequestAttributes requestAttributes =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+    HttpServletRequest request = Objects.requireNonNull(requestAttributes).getRequest();
+    String traceId = (String) request.getAttribute("traceId");
+    Map<String, String> params = getParameter(request);
+    String className = joinPoint.getSignature().getDeclaringTypeName();
+    String methodName = joinPoint.getSignature().getName();
+    RequestResponseLogging reqResLogging =
+        new RequestResponseLogging(
+            traceId,
+            className,
+            methodName,
+            request.getMethod(),
+            request.getRequestURI(),
+            params,
+            objectMapper.readTree(request.getInputStream().readAllBytes()),
+            null);
+    try {
+      Object result = joinPoint.proceed();
+      if (result instanceof ResponseEntity) {
+        reqResLogging.updateResponseBody(((ResponseEntity<?>) result).getBody());
+      } else {
+        reqResLogging.updateResponseBody("{}");
+      }
+      log.info(objectMapper.writeValueAsString(result));
+      return result;
+    } catch (Throwable e) {
+      log.info("{}", objectMapper.writeValueAsString(reqResLogging));
+      throw e;
+    }
+  }
+
+  private Map<String, String> getParameter(HttpServletRequest request) {
+    Map<String, String> jsonObject = new HashMap<>();
+    Enumeration<String> paramNames = request.getParameterNames();
+
+    while (paramNames.hasMoreElements()) {
+      String paramName = paramNames.nextElement();
+      String replaceParam = paramName.replaceAll("\\.", "-");
+      jsonObject.put(replaceParam, request.getParameter(paramName));
+    }
+    return jsonObject;
+  }
+}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
@@ -31,7 +31,7 @@ public class ApiRequestResponseAop {
   public void apiRestPointCut() {}
 
   @Around("apiRestPointCut()")
-  public Object reqeustResponseLogging(ProceedingJoinPoint joinPoint) throws Throwable {
+  public Object requestResponseLogging(ProceedingJoinPoint joinPoint) throws Throwable {
     boolean isFirst = !isFirstRequest.get();
     if (isFirst) {
       isFirstRequest.set(true);

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/ApiRequestResponseAop.java
@@ -11,7 +11,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
-import org.springframework.http.ResponseEntity;
+import org.nexters.jaknaesocore.common.support.response.ApiResponse;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -56,8 +56,8 @@ public class ApiRequestResponseAop {
     try {
       Object result = joinPoint.proceed();
       if (isFirst) {
-        if (result instanceof ResponseEntity) {
-          reqResLogging.updateResponseBody(((ResponseEntity<?>) result).getBody());
+        if (result instanceof ApiResponse<?>) {
+          reqResLogging.updateResponseBody(((ApiResponse<?>) result).getData());
         } else {
           reqResLogging.updateResponseBody("{}");
         }

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/CachedBodyHttpServletRequest.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/CachedBodyHttpServletRequest.java
@@ -1,0 +1,24 @@
+package org.nexters.jaknaesoserver.logging;
+
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import java.io.IOException;
+import java.io.InputStream;
+import org.springframework.util.StreamUtils;
+
+public class CachedBodyHttpServletRequest extends HttpServletRequestWrapper {
+
+  private final byte[] cachedBody;
+
+  public CachedBodyHttpServletRequest(HttpServletRequest request) throws IOException {
+    super(request);
+    InputStream requestInputStream = request.getInputStream();
+    this.cachedBody = StreamUtils.copyToByteArray(requestInputStream);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() {
+    return new CachedBodyServletInputStream(this.cachedBody);
+  }
+}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/CachedBodyServletInputStream.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/CachedBodyServletInputStream.java
@@ -1,0 +1,40 @@
+package org.nexters.jaknaesoserver.logging;
+
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class CachedBodyServletInputStream extends ServletInputStream {
+
+  private final InputStream cachedBodyInputStream;
+
+  protected CachedBodyServletInputStream(byte[] cachedBody) {
+    this.cachedBodyInputStream = new ByteArrayInputStream(cachedBody);
+  }
+
+  @Override
+  public int read() throws IOException {
+    return cachedBodyInputStream.read();
+  }
+
+  @Override
+  public boolean isFinished() {
+    try {
+      return cachedBodyInputStream.available() == 0;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean isReady() {
+    return true;
+  }
+
+  @Override
+  public void setReadListener(ReadListener readListener) {
+    // TODO: Implement this method
+  }
+}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/RequestResponseFilter.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/RequestResponseFilter.java
@@ -1,0 +1,49 @@
+package org.nexters.jaknaesoserver.logging;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.nexters.jaknaesocore.common.support.error.CustomException;
+import org.nexters.jaknaesocore.common.support.error.ErrorType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Slf4j
+@Component
+public class RequestResponseFilter extends OncePerRequestFilter {
+
+  private final ObjectMapper objectMapper;
+
+  public RequestResponseFilter(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    String traceId = UUID.randomUUID().toString();
+    try {
+      CachedBodyHttpServletRequest requestWrapper = new CachedBodyHttpServletRequest(request);
+      requestWrapper.setAttribute("traceId", traceId);
+      filterChain.doFilter(requestWrapper, response);
+    } catch (Exception e) {
+      log.error(e.getMessage());
+      CustomException customException = new CustomException(ErrorType.DEFAULT_ERROR);
+      try {
+        PrintWriter printWriter = response.getWriter();
+        printWriter.print(objectMapper.writeValueAsString(customException));
+        printWriter.flush();
+      } catch (IOException ex) {
+        log.warn("IOException Occur");
+        throw new RuntimeException();
+      }
+    }
+  }
+}

--- a/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/RequestResponseLogging.java
+++ b/jaknaeso-server/src/main/java/org/nexters/jaknaesoserver/logging/RequestResponseLogging.java
@@ -1,0 +1,39 @@
+package org.nexters.jaknaesoserver.logging;
+
+import java.util.Map;
+import lombok.Getter;
+
+@Getter
+public class RequestResponseLogging {
+  String traceId;
+  String className;
+  String methodName;
+  String httpMethod;
+  String uri;
+  Map<String, String> params;
+  Object requestBody;
+  Object responseBody;
+
+  public RequestResponseLogging(
+      String traceId,
+      String className,
+      String methodName,
+      String httpMethod,
+      String uri,
+      Map<String, String> params,
+      Object requestBody,
+      Object responseBody) {
+    this.traceId = traceId;
+    this.className = className;
+    this.methodName = methodName;
+    this.httpMethod = httpMethod;
+    this.uri = uri;
+    this.params = params;
+    this.requestBody = requestBody;
+    this.responseBody = responseBody;
+  }
+
+  public void updateResponseBody(Object responseBody) {
+    this.responseBody = responseBody;
+  }
+}

--- a/jaknaeso-server/src/main/resources/application-dev.yaml
+++ b/jaknaeso-server/src/main/resources/application-dev.yaml
@@ -1,2 +1,2 @@
 logging:
-  config: classpath:log/log4j2-dev.yml
+  config: classpath:log/logback-dev.xml

--- a/jaknaeso-server/src/main/resources/application-local.yaml
+++ b/jaknaeso-server/src/main/resources/application-local.yaml
@@ -1,11 +1,11 @@
 spring:
 
   datasource:
-    url: jdbc:log4jdbc:p6spy:mysql://${DATABASE_HOST}/${DATABASE_NAME}
+    url: jdbc:p6spy:mysql://${DATABASE_HOST}/${DATABASE_NAME}
     hikari:
       username: ${DATABASE_USER}
       password: ${DATABASE_PASSWORD}
-    driver-class-name: net.sf.log4jdbc.sql.jdbcapi.DriverSpy
+    driver-class-name: com.p6spy.engine.spy.P6SpyDriver
 
   jpa:
     hibernate:
@@ -13,12 +13,4 @@ spring:
 
 
 logging:
-  config: classpath:log/log4j2-local.yml
-  decorator:
-    datasource:
-      p6spy:
-        enable-logging: true
-        multiline: true
-        logging: SLF4J
-        tracing:
-          include-parameter-values: true
+  config: classpath:log/logback-local.xml

--- a/logstash.conf
+++ b/logstash.conf
@@ -1,0 +1,13 @@
+input {
+    tcp {
+        port => 5044
+        codec => json
+    }
+}
+
+output {
+    elasticsearch {
+        hosts => ["http://elasticsearch:9200"]
+        index => "application-logs-%{+YYYY.MM.dd}"
+    }
+}


### PR DESCRIPTION
<!-- 🔥 다음 양식으로 제목을 작성해주세요 : 한 일의 type(#issue number): 작업 내용 -->
<!-- ex) Feat(#133): canvas 구현~ -->
<!-- "여기에 작성하세요", "(필수 X)"는 지우고 작성하세요 🙏🏻 -->

## 작업 개요
<!-- 작업에 대한 설명을 간단하게 작성해주세요. -->
로깅이 너무 불편해서 ES에 적재하도록 변경

## 작업 사항
<!-- 작업에 대한 설명을 코드와 관련하여 남겨주세요. -->
- log4j2 에서 logback으로 변경
- es에 로그 데이터 적재
- 로그 추적을 편하게 하기 위해 traceId 추가

## 고민한 점들(필수 X)
<!-- 작업을 진행하면서 고민했던 점들을 추가해주세요 -->
log4j2로 appender 중에 socket 사용하면 적재가 가능하다고 하는데 잘 안되가지구 그냥 logback으로 회귀했습니다.
그리고 elk올리니까 서버 메모리가 터져서 스왑메모리 4기가 정도했습니다.

로그 추적을 편하게 하기 위해서 aop 적용해서 traceId를 생성해서 로그에 남기고, 클라이언트측에 전송하도록 하여서 좀 더 예외상황에 대해서 소통하기 쉽게 할 수 있도록 변경하였습니다. 클라이언트측에서 traceId를 전달해주면 해당 값을 이용해서 로그를 확인하면 될 것 같습니다 !(그런데 시큐리티에서 발생하는 예외는 AOP 로그로 남지 않습니다..)

단순히 traceId만 필요하면 앞단에 필터를 걸면 될 것 같은데 500발생 시 해당 예외가 발생한 method와 signature를 확인하기 위해서 사용하면 좋을 것 같아서 사용해봤습니다 !

## 스크린샷(필수 X)
<!-- 작업을 파악하는 데 도움이 되는 스크린샷을 추가해주세요 -->

<img width="1564" alt="스크린샷 2025-02-28 오후 8 17 05" src="https://github.com/user-attachments/assets/80466a62-5a37-4dc4-9127-97bfff917638" />

~~고작 이따구로 보이긴 하는데 천천히 Kibana도 설정할 수 있도록 해보겠습니다..
더이상 cat으로는 못보겠어요 ㅜㅜ~~
TraceID가 있어서 좀 더 로깅은 쉬울 것 같습니다. 

## 추가 작업 사항
- [x] 로그레벨 조정
- [ ] 키바나 대시보드 만들기

## 확인법
제가 테라폼으로 코드를 만들었지만.. 서버 옮기고 나서 테라폼 수정하는법을 몰라서.. 보안그룹에 작업환경의 5601 포트 추가해주시고 확인하시면 될 것 같습니다 !

~~PR은 천천히 리뷰해주셔도 될 것 같아여 아직 할게많아서.. 그냥 ELK만 제대로 올라가게 확인한거라서 ㅎㅎ~~